### PR TITLE
56 format dates

### DIFF
--- a/client/src/pages/AdminDashboard.js
+++ b/client/src/pages/AdminDashboard.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link, Redirect } from 'react-router-dom';
 import { round } from 'mathjs';
+import moment from 'moment';
 
 import useAuth from '../hooks/useAuth';
 
@@ -240,7 +241,7 @@ const AdminDashboard = (props) => {
                                 <p className="event-name">{nextEvent[0].name}</p>
                                 <div className="event-info-wrapper">
                                     <ClockIcon />
-                                    <p className="event-info">{nextEvent[0].date}</p>
+                                    <p className="event-info">{moment(nextEvent[0].date).format('ddd, MMM D @ h:mm a')}</p>
                                 </div>
                                 <div className="event-info-wrapper">
                                     <LocationIcon />

--- a/client/src/pages/CheckInForm.js
+++ b/client/src/pages/CheckInForm.js
@@ -80,15 +80,15 @@ const CheckInForm = (props) => {
     const handleNewMemberChange = (e) => {
         if (e.target.value === "true") {
             setNewMember(true);
-            setMonth("JAN");
-            setYear("2020");
+            setMonth(moment().format('MMM').toUpperCase());
+            setYear(moment().format('YYYY'));
         }
 
         if (e.target.value === "false") {
             setNewMember(false);
         }
     };
-
+    
     const submitForm = (userForm) => {
         // First, create a new user in the user collection
         const headerToSend = process.env.REACT_APP_CUSTOM_REQUEST_HEADER;

--- a/client/src/pages/CheckInForm.js
+++ b/client/src/pages/CheckInForm.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import moment from 'moment';
 
 import '../sass/CheckIn.scss';
 
@@ -19,8 +20,8 @@ const CheckInForm = (props) => {
     const [firstName, setFirstName] = useState("");
     const [lastName, setLastName] = useState("");
     const [newMember, setNewMember] = useState(true);
-    const [month, setMonth] = useState("JAN");
-    const [year, setYear] = useState("2020");
+    const [month, setMonth] = useState(moment().format('MMM').toUpperCase());
+    const [year, setYear] = useState(moment().format("YYYY"));
     const [reason, setReason] = useState("--SELECT ONE--");
     const [project, setProject] = useState("--SELECT ONE--");
     const [user, setUser] = useState(null);

--- a/client/src/pages/CheckInForm.js
+++ b/client/src/pages/CheckInForm.js
@@ -268,7 +268,7 @@ const CheckInForm = (props) => {
     //         setIsFormReady(false);
     //     }  
     // } 
-
+    
     const checkInNewUser = (e) => {
         e.preventDefault();
 
@@ -302,8 +302,14 @@ const CheckInForm = (props) => {
                 setErrorMessage("Please don't leave any fields blank");
                 ready = false;
             } 
-
-            if(year === "2020" && month !== "JAN" && month !== "FEB") {
+            
+            const currYear = parseInt(moment().format('YYYY'));
+            const currMonth = parseInt(moment().format('MM'));
+            const yearJoined = parseInt(year);
+            // extra date info needed to be recognized as a date
+            const monthJoined = parseInt(moment(month + ' 9, 2020').format('MM')); 
+            console.log(currYear, currMonth, yearJoined, monthJoined);
+            if(yearJoined > currYear || (yearJoined === currYear && monthJoined > currMonth)) {
                 setIsError(true);
                 setErrorMessage("You can't set a date in the future... Please try again.");
                 ready = false;
@@ -391,7 +397,7 @@ const CheckInForm = (props) => {
         fetchQuestions();
 
     }, []);
-
+    
     return (
         <div className="flex-container">
             {newOrReturning === 'returningUser' ? (

--- a/client/src/pages/Event.js
+++ b/client/src/pages/Event.js
@@ -90,7 +90,7 @@ const Event = (props) => {
                     <div className="event-headers">
                         <h4>{event.name}</h4>
                         {/* <h5>RSVP's: {event.rsvps.length}</h5> */}
-                        <p>{moment(event.date).format('dddd, MMMM D, YYYY')}</p>
+                        <p>{moment(event.date).format('dddd, MMMM D, YYYY @ h:mm a')}</p>
                         <p>{event.location.city}</p>
                         <p>{event.location.state}</p>
                     </div>

--- a/client/src/pages/Event.js
+++ b/client/src/pages/Event.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-
+import moment from 'moment';
 
 import '../sass/Event.scss';
 // import '../sass/Event-media-queries.scss';
@@ -90,7 +90,7 @@ const Event = (props) => {
                     <div className="event-headers">
                         <h4>{event.name}</h4>
                         {/* <h5>RSVP's: {event.rsvps.length}</h5> */}
-                        <p>{event.date}</p>
+                        <p>{moment(event.date).format('dddd, MMMM D, YYYY')}</p>
                         <p>{event.location.city}</p>
                         <p>{event.location.state}</p>
                     </div>

--- a/client/src/pages/Events.js
+++ b/client/src/pages/Events.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Link, Redirect } from 'react-router-dom';
+import moment from 'moment';
 
 import useAuth from '../hooks/useAuth';
 
@@ -46,7 +47,7 @@ const Events = (props) => {
                                                 <div className="event-info-container">
                                                     <div className="event-info-wrapper">
                                                         <ClockIcon />
-                                                        <p className="event-info-text">{event.date}</p>
+                                                        <p className="event-info-text">{moment(event.date).format('ddd, MMM D')}</p>
                                                     </div>
                                                     <div className="event-info-wrapper">
                                                         <LocationIcon />

--- a/client/src/pages/Events.js
+++ b/client/src/pages/Events.js
@@ -47,7 +47,7 @@ const Events = (props) => {
                                                 <div className="event-info-container">
                                                     <div className="event-info-wrapper">
                                                         <ClockIcon />
-                                                        <p className="event-info-text">{moment(event.date).format('ddd, MMM D')}</p>
+                                                        <p className="event-info-text">{moment(event.date).format('ddd, MMM D @ h:mm a')}</p>
                                                     </div>
                                                     <div className="event-info-wrapper">
                                                         <LocationIcon />

--- a/client/src/sass/Events.scss
+++ b/client/src/sass/Events.scss
@@ -52,7 +52,7 @@
 }
 
 .event-info-text {
-    margin: 0px 0px 0px 12px;
+    margin: 0px 12px 0px;
 }
 
     


### PR DESCRIPTION
Resolves hackforla/VRMS#56.

**Adds dynamic dates (CheckInForm) and formats displayed dates (Event, Events, AdminDashboard) using moment.js.** 

Package.json is not included per your request. 

Feel free to let me know if you want the format to be displayed differently. I couldn't figure out how to have an option that shortens times when possible (e.g., 6pm vs 6:00pm but still preserves something like 6:30pm). I can figure out how to code that in JS, if really preferred. 