### PR TITLE
adds, eventType, session, and hours to Event schema

### DIFF
--- a/models/event.model.js
+++ b/models/event.model.js
@@ -10,7 +10,10 @@ const eventSchema = mongoose.Schema({
         country: { type: String }
     },
     hacknight: { type: String },
+    eventType: { type: String }, 
+    session: { type: String },
     date: { type: Date },
+    hours: { type: Number },
     createdDate: { type: Date, default: Date.now },
     updatedDate: { type: Date, default: Date.now },
     checkInCount: { type: Number, default: 0 },


### PR DESCRIPTION
Resolves #64 . 

I retained camelcasing to keep consistent with the prior keys in the schema, instead of applying underscore casing as requested in the issue. If preferred I can update all keys to use underscore casing.