### PR TITLE
Hotfix/prevent checkin when empty email

### DIFF
--- a/client/src/components/presentational/returnUserForm.js
+++ b/client/src/components/presentational/returnUserForm.js
@@ -50,6 +50,7 @@ const ReturnUserForm = (props) => {
                   type="submit"
                   className="form-check-in-submit"
                   onClick={(e) => props.checkEmail(e)}
+                  disabled={!!!props.formInput.email}
                 >
                   CHECK IN
                 </button>

--- a/client/src/pages/CheckInForm.js
+++ b/client/src/pages/CheckInForm.js
@@ -206,7 +206,12 @@ const submitReturning = (returningUser, e = null) => {
                 }
             })
             .then(res => {
-                return res.json();
+              console.log('res.ok, 209', res.ok);
+              if (res.ok) {
+                return res.json(); 
+              }
+
+              throw new Error(res.statusText)
             })
             .then(response => {
                 const checkInForm = { userId: `${returningUser._id}`, eventId: new URLSearchParams(props.location.search).get('eventId') };
@@ -222,14 +227,29 @@ const submitReturning = (returningUser, e = null) => {
                 })
                 .then(res => {
                     if (res.ok) {
-                        props.history.push('/success');
+                      return props.history.push('/success'); 
                     }
+                    console.log('throwing new error in line 230');
+                    throw new Error(res.statusText);
                 })
-                .catch(err => console.log(err));
-            })                    
-            .catch(err => console.log(err));
+                .catch(error => {
+                  console.log(error.error);
+                  setIsError(true);
+                  setErrorMessage(error);
+                  setIsLoading(false);
+                })
+            })
+            .catch(error => {
+              console.log(error);
+              setIsError(true);
+              setErrorMessage(error);
+              setIsLoading(false);
+            })              
         } catch (error) {
             console.log(error);
+            setIsError(true);
+            setErrorMessage(error);
+            setIsLoading(false);
         }
     // }
 }
@@ -398,6 +418,10 @@ const checkEmail = (e) => {
     e.preventDefault();
 
     try {
+        if (!formInput.email) {
+          throw new Error("User email is required");
+        }
+
         setIsLoading(true);
 
         fetch('/api/checkuser', {
@@ -426,6 +450,8 @@ const checkEmail = (e) => {
         })
     } catch (error) {
         console.log(error);
+        setIsError(true);
+        setErrorMessage(error)
         setIsLoading(false);
     }
 }

--- a/routers/checkUser.router.js
+++ b/routers/checkUser.router.js
@@ -7,6 +7,10 @@ const { User } = require('../models/user.model');
 router.post('/', (req, res) => {
     const { email } = req.body;
     console.log(email);
+    
+    if(email === "undefined") {
+        return res.sendStatus(412).json({ message: "user email is required"})
+    }
 
     if(email) {
         User

--- a/routers/users.router.js
+++ b/routers/users.router.js
@@ -65,6 +65,11 @@ router.patch('/:id', (req, res) => {
     const { headers } = req;
     const expectedHeader = process.env.CUSTOM_REQUEST_HEADER;
 
+    // Return 412 status if no userId
+    if (req.params.id === "undefined") {
+        return res.status(412).json({ error: "user id required" })
+    }
+    
     if (headers['x-customrequired-header'] !== expectedHeader) {
         res.sendStatus(401);
     } else {


### PR DESCRIPTION
Fixes bug that allows users to submit a check-in without first inputting an email. Includes validation code for both front-end and back-end. No corresponding github issue open (as of creation of this PR).

- Adds validation in API for `POST /checkuser`, `PATCH /users`
- Disables "check in" button for returning users if email field is empty 
-   - probably need to add styling to reflect this, I had a hard time doing this quickly 
- Adds validation in front end function `checkEmail` to throw error as necessary. 
-   - fixes errors in initial fetch promise chain `res.ok` check to throw error as necessary + other error handling