### PR TITLE
adds empty field check and disable btn styling

### DIFF
--- a/client/src/components/presentational/returnUserForm.js
+++ b/client/src/components/presentational/returnUserForm.js
@@ -51,7 +51,7 @@ const ReturnUserForm = (props) => {
                   type="submit"
                   className="form-check-in-submit"
                   onClick={(e) => props.checkEmail(e)}
-                  disabled={!!!props.formInput.email}
+                  disabled={!props.formInput.email || props.formInput.email===""}
                 >
                   CHECK IN
                 </button>

--- a/client/src/sass/CheckIn.scss
+++ b/client/src/sass/CheckIn.scss
@@ -134,11 +134,10 @@ input[type=radio] {
     height: 40px;
     margin-top: 20px;
     margin-bottom: 36px;
-    border: 3px solid black;
-    border-radius: 4px;
-    font-weight: bold;
-
     button {
+        border: 3px solid black;
+        border-radius: 4px;
+        font-weight: bold;
         font-size: 18px;
         font-weight: bold;
         transition: all .3s ease-in-out;
@@ -147,6 +146,12 @@ input[type=radio] {
             background-color: black;
             color: white;
         }
+        &:disabled {
+            color: #bbb;
+            border-color: #bbb;
+            pointer-events: none;
+        }
+        
     }
 }
 


### PR DESCRIPTION
Fix for issue #219 : disabling button when the email text box is empty.

I added in a test to make sure the email string isn't empty. I also added some :disabled styling in Checkin.scss. 
Note: the component structure of the checkin/login forms can use a refactor.

![disabled_button_sm](https://user-images.githubusercontent.com/11682523/90478807-86fa4200-e0e2-11ea-9f8d-e4a73ca33923.gif)
