### PR TITLE
Hotfix/env files

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -24,7 +24,7 @@
     "react-scripts": "^3.4.1"
   },
   "scripts": {
-    "start": "dotenv -e .env -- cross-var cross-env PORT=%CLIENT_PORT% react-scripts start",
+    "start": "dotenv -e .env -e ../backend/.env -- cross-var cross-env PORT=%CLIENT_PORT% react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --watchAll=false",
     "test:watch": "react-scripts test",


### PR DESCRIPTION
The backend runs on a set port by running command line arguments as seen in the package.json. The work done to move all path variables to the .env files was done in a DRY fashion. In an attempt to keep from having to duplicate the backend port in two files, which may have caused confusion for devs down the line, I opted to keep these separate. This change now allows devs to run the client independently of the backend, while still sourcing the backend port. The only difference now is that there is one environment variable import in the src/setupProxy.js file. If you need more information on this, then please refer to this https://create-react-app.dev/docs/adding-custom-environment-variables/