### PR TITLE
Redirect invalid urls

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -61,11 +61,9 @@ const CLIENT_BUILD_PATH = path.join(__dirname, "../client/build");
 // Serve static files from the React frontend app
 app.use(express.static(path.join(CLIENT_BUILD_PATH)));
 
-// Anything that doesn't match the above, send back index.html
+// 404 for all non-defined endpoints.
 app.get("*", (req, res) => {
-  const index = path.join(CLIENT_BUILD_PATH, "index.html");
-
-  res.sendFile(index);
+  res.sendStatus(404);
 });
 
 module.exports = app;

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { AuthProvider } from "./context/authContext";
-import { Route } from "react-router-dom";
+import { Route, Redirect, Switch } from "react-router-dom";
 
 import Firebase from "./firebase";
 
@@ -25,26 +25,26 @@ import ProjectLeaderDashboard from "./pages/ProjectLeaderDashboard";
 import "./App.scss";
 
 const routes = [
-    { path: "/", name: "home", Component: Home },
-    { path: "/admin", name: "admindashboard", Component: AdminDashboard },
-    { path: "/user", name: "userdashboard", Component: UserDashboard },
-    { path: "/profile", name: "profile", Component: UserProfile },
-    { path: "/event/:id", name: "event", Component: Event },
-    { path: "/new", name: "new", Component: NewUser },
-    { path: "/returning", name: "returning", Component: ReturningUser },
-    { path: "/login", name: "login", Component: AdminLogin },
-    { path: "/checkIn/:userType", name: "checkIn", Component: CheckInForm },
-    { path: "/newProfile", name: "newProfile", Component: CheckInForm },
-    { path: "/success", name: "success", Component: Success },
-    { path: "/handleauth", name: "handleauth", Component: HandleAuth },
-    { path: "/emailsent", name: "emailsent", Component: EmailSent },
-    { path: "/events", name: "events", Component: Events },
-    {
-        path: "/projectleader",
-        name: "pldashboard",
-        Component: ProjectLeaderDashboard,
-    },
-    { path: "/add/:item", name: "addnew", Component: AddNew }
+  { path: "/", name: "home", Component: Home },
+  { path: "/admin", name: "admindashboard", Component: AdminDashboard },
+  { path: "/user", name: "userdashboard", Component: UserDashboard },
+  { path: "/profile", name: "profile", Component: UserProfile },
+  { path: "/event/:id", name: "event", Component: Event },
+  { path: "/new", name: "new", Component: NewUser },
+  { path: "/returning", name: "returning", Component: ReturningUser },
+  { path: "/login", name: "login", Component: AdminLogin },
+  { path: "/checkIn/:userType", name: "checkIn", Component: CheckInForm },
+  { path: "/newProfile", name: "newProfile", Component: CheckInForm },
+  { path: "/success", name: "success", Component: Success },
+  { path: "/handleauth", name: "handleauth", Component: HandleAuth },
+  { path: "/emailsent", name: "emailsent", Component: EmailSent },
+  { path: "/events", name: "events", Component: Events },
+  {
+    path: "/projectleader",
+    name: "pldashboard",
+    Component: ProjectLeaderDashboard,
+  },
+  { path: "/add/:item", name: "addnew", Component: AddNew },
 ];
 
 const App = () => {
@@ -54,9 +54,12 @@ const App = () => {
         <div className="app-container">
           <Navbar />
           <main role="main" className="main">
-            {routes.map(({ path, Component }) => (
-              <Route key={path} exact path={path} component={Component} />
-            ))}
+            <Switch>
+              {routes.map(({ path, Component }) => (
+                <Route key={path} exact path={path} component={Component} />
+              ))}
+              <Redirect to="/" />
+            </Switch>
           </main>
           <Footer />
         </div>


### PR DESCRIPTION
I have been noticing that the API only serves up empty pages on non-defined API end points. Users are also able to navigate to non-functional pages and endpoints in the frontend. This change makes it so that a user is redirected to the homepage when they try to navigate to a non-defined page. All requests to non-defined api-endpoints now return a 404 (not implemented). 

I believe that this will give a lot better interface for users. 