### PR TITLE
Frontend linter 2

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,22 @@
 {
-    "workbench.colorCustomizations": {
-        "editorRuler.foreground": "#ff4081",
-        "activityBar.background": "#322F03",
-        "titleBar.activeBackground": "#464204",
-        "titleBar.activeForeground": "#FDFBE1"
-    }
+  "workbench.colorCustomizations": {
+    "editorRuler.foreground": "#ff4081",
+    "activityBar.background": "#322F03",
+    "titleBar.activeBackground": "#464204",
+    "titleBar.activeForeground": "#FDFBE1"
+  },
+  "editor.formatOnSave": true,
+  "files.autoSave": "afterDelay",
+  "files.autoSaveDelay": 1500,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[javascript]": {
+    "editor.insertSpaces": true,
+    "editor.tabSize": 2,
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.codeActionsOnSave": {
+      "source.fixAll": true
+    },
+    "editor.formatOnSave": true
+  },
+  "eslint.enable": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,7 @@
     "editor.codeActionsOnSave": {
       "source.fixAll": true
     },
-    "editor.formatOnSave": true
+    "editor.formatOnSave": false
   },
   "eslint.enable": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,19 +4,5 @@
     "activityBar.background": "#322F03",
     "titleBar.activeBackground": "#464204",
     "titleBar.activeForeground": "#FDFBE1"
-  },
-  "editor.formatOnSave": true,
-  "files.autoSave": "afterDelay",
-  "files.autoSaveDelay": 1500,
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "[javascript]": {
-    "editor.insertSpaces": true,
-    "editor.tabSize": 2,
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.codeActionsOnSave": {
-      "source.fixAll": true
-    },
-    "editor.formatOnSave": false
-  },
-  "eslint.enable": true
+  }
 }

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -1,0 +1,29 @@
+{
+  "env": {
+    "browser": true,
+    "es2017": true
+  },
+  "extends": [
+    "plugin:react/recommended",
+    "airbnb",
+    "airbnb-base",
+    "plugin:prettier/recommended",
+    "plugin:react-hooks/recommended"
+  ],
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "ecmaVersion": 2017,
+    "sourceType": "module"
+  },
+  "plugins": ["react"],
+  "rules": {
+    "react/jsx-filename-extension": [
+      1,
+      {
+        "extensions": [".js", ".jsx"]
+      }
+    ]
+  }
+}

--- a/client/.prettierrc.json
+++ b/client/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/client/package.json
+++ b/client/package.json
@@ -49,6 +49,13 @@
   "author": "sarL3y",
   "license": "ISC",
   "devDependencies": {
+    "eslint": "^7.9.0",
+    "eslint-config-airbnb-base": "^14.2.0",
+    "eslint-config-prettier": "^6.11.0",
+    "eslint-plugin-import": "^2.22.0",
+    "eslint-plugin-prettier": "^3.1.4",
+    "eslint-plugin-react-hooks": "^4.1.2",
+    "prettier": "^2.1.2",
     "react-test-renderer": "^16.13.1"
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -49,7 +49,6 @@
   "author": "sarL3y",
   "license": "ISC",
   "devDependencies": {
-    "eslint": "^7.9.0",
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-import": "^2.22.0",

--- a/client/package.json
+++ b/client/package.json
@@ -49,12 +49,15 @@
   "author": "sarL3y",
   "license": "ISC",
   "devDependencies": {
+    "eslint-config-airbnb": "^18.2.0",
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-import": "^2.22.0",
+    "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-prettier": "^3.1.4",
+    "eslint-plugin-react": "^7.20.6",
     "eslint-plugin-react-hooks": "^4.1.2",
-    "prettier": "^2.1.2",
+    "prettier": "^2.1.1",
     "react-test-renderer": "^16.13.1"
   }
 }

--- a/client/src/pages/AdminDashboard.js
+++ b/client/src/pages/AdminDashboard.js
@@ -1,17 +1,17 @@
-import React, { useState, useEffect } from 'react';
-import { Redirect } from 'react-router-dom';
+import React, { useState, useEffect } from "react";
+import { Redirect } from "react-router-dom";
 
-import useAuth from '../hooks/useAuth';
+import useAuth from "../hooks/useAuth";
 
-import '../sass/Dashboard.scss';
-import UpcomingEvent from '../components/presentational/upcomingEvent';
-import EventOverview from '../components/presentational/eventOverview';
-import DonutChartContainer from '../components/presentational/donutChartContainer';
-import Loading from '../components/presentational/donutChartLoading';
+import "../sass/Dashboard.scss";
+import UpcomingEvent from "../components/presentational/upcomingEvent";
+import EventOverview from "../components/presentational/eventOverview";
+import DonutChartContainer from "../components/presentational/donutChartContainer";
+import Loading from "../components/presentational/donutChartLoading";
 
 const AdminDashboard = (props) => {
   const auth = useAuth();
-  const defaultChartType = 'All Events';
+  const defaultChartType = "All Events";
   let uniqueEventTypes = new Set();
   let hackNightUniqueLocations = new Set();
 
@@ -24,31 +24,14 @@ const AdminDashboard = (props) => {
   const [chartTypes, setChartTypes] = useState(null);
 
   // Volunteers SignedIn By Event Type
-  const [
-    totalVolunteersByEventType,
-    setVolunteersSignedInByEventType,
-  ] = useState({});
-  const [
-    totalVolunteerHoursByEventType,
-    setVolunteeredHoursByEventType,
-  ] = useState({});
-  const [totalVolunteerAvgHoursByEventType, setAvgHoursByEventType] = useState(
-    {}
-  );
+  const [totalVolunteersByEventType, setVolunteersSignedInByEventType] = useState({});
+  const [totalVolunteerHoursByEventType, setVolunteeredHoursByEventType] = useState({});
+  const [totalVolunteerAvgHoursByEventType, setAvgHoursByEventType] = useState({});
 
   // Volunteers SignedIn By Hacknight Property
-  const [
-    totalVolunteersByHacknightProp,
-    setVolunteersSignedInByHacknightProp,
-  ] = useState({});
-  const [
-    totalVolunteerHoursByHacknightProp,
-    setVolunteeredHoursByHacknightProp,
-  ] = useState({});
-  const [
-    totalVolunteerAvgHoursByHacknightProp,
-    setAvgHoursByHacknightProp,
-  ] = useState({});
+  const [totalVolunteersByHacknightProp, setVolunteersSignedInByHacknightProp] = useState({});
+  const [totalVolunteerHoursByHacknightProp, setVolunteeredHoursByHacknightProp] = useState({});
+  const [totalVolunteerAvgHoursByHacknightProp, setAvgHoursByHacknightProp] = useState({});
 
   // Volunteers To Chart
   const [totalVolunteers, setVolunteersToChart] = useState({});
@@ -60,9 +43,9 @@ const AdminDashboard = (props) => {
   async function getAndSetData() {
     try {
       setIsLoading(true);
-      const checkIns = await fetch('/api/checkins');
+      const checkIns = await fetch("/api/checkins");
       const checkInsJson = await checkIns.json();
-      const events = await fetch('/api/events');
+      const events = await fetch("/api/events");
       const eventsJson = await events.json();
 
       processData(eventsJson, checkInsJson);
@@ -73,7 +56,7 @@ const AdminDashboard = (props) => {
     }
   }
 
-  function processData(allEvents, allCheckIns) {
+  function processData(allEvents, allCheckIns){
     let processedEvents = processEvents(allEvents);
     let usersByEvent = collectUsersByEvent(allCheckIns);
     prepareDataForCharts(processedEvents, usersByEvent);
@@ -82,14 +65,14 @@ const AdminDashboard = (props) => {
   function processEvents(allEvents) {
     let events = new Map();
 
-    for (let event of allEvents) {
+    for (let event of allEvents){
       // Process legacy data with undefined 'hours' property because initially an event length was 3 hours
-      if (!event.hours) {
+      if(!event.hours){
         event.hours = 3;
       }
 
       // Define unique event types and process events without 'eventType' property
-      if (event.eventType) {
+      if(event.eventType){
         processEventTypes(event, 'eventType', uniqueEventTypes);
       } else {
         // Find events without 'eventType' property (30 events) and assign it
@@ -97,7 +80,7 @@ const AdminDashboard = (props) => {
       }
 
       // Extract events with 'hacknight' property & find unique locations in it
-      if (event.hacknight) {
+      if(event.hacknight){
         processEventTypes(event, 'hacknight', hackNightUniqueLocations);
       }
       events.set(event._id, event);
@@ -106,83 +89,58 @@ const AdminDashboard = (props) => {
     return events;
   }
 
-  function processEventTypes(event, propName, uniqueTypes) {
+  function processEventTypes(event, propName, uniqueTypes){
     const capitalize = (str, lower = false) =>
-      (lower ? str.toLowerCase() : str).replace(
-        /(?:^|\s|["'([{])+\S/g,
-        (match) => match.toUpperCase()
-      );
+        (lower ? str.toLowerCase() : str).replace(/(?:^|\s|["'([{])+\S/g, match => match.toUpperCase());
     let type = capitalize(event[propName], true);
     event[propName] = type;
     uniqueTypes.add(type);
   }
 
-  function createChartTypes() {
+  function createChartTypes(){
     let chartTypes = {
-      'All Events': '',
-      'Hacknight Only': '',
+      "All Events": "",
+      "Hacknight Only": ""
     };
     setChartTypes(chartTypes);
   }
 
-  function collectUsersByEvent(allCheckIns) {
+  function collectUsersByEvent(allCheckIns){
     let eventCollection = new Map();
-    for (let checkIn of allCheckIns) {
-      if (eventCollection.has(checkIn.eventId)) {
+    for(let checkIn of allCheckIns){
+      if(eventCollection.has(checkIn.eventId)){
         eventCollection.get(checkIn.eventId).push(checkIn);
-      } else {
+      } else{
         eventCollection.set(checkIn.eventId, [checkIn]);
       }
     }
     return eventCollection;
   }
 
-  function prepareDataForCharts(events, users) {
+  function prepareDataForCharts(events, users){
     // Data for 1 chart 'total volunteers'
-    let totalVolunteersByEventType = extractVolunteersSignedInByProperty(
-      events,
-      users,
-      uniqueEventTypes,
-      'eventType'
-    );
+    let totalVolunteersByEventType = extractVolunteersSignedInByProperty(events, users, uniqueEventTypes, 'eventType');
     setVolunteersSignedInByEventType(totalVolunteersByEventType);
-    let totalVolunteersByHacknightProp = extractVolunteersSignedInByProperty(
-      events,
-      users,
-      hackNightUniqueLocations,
-      'hacknight'
-    );
+    let totalVolunteersByHacknightProp = extractVolunteersSignedInByProperty(events, users, hackNightUniqueLocations, 'hacknight');
     setVolunteersSignedInByHacknightProp(totalVolunteersByHacknightProp);
 
     // Data for 2 chart 'total hours'
-    let totalVolunteerHoursByEventType = findTotalVolunteerHours(
-      events,
-      users,
-      uniqueEventTypes,
-      'eventType'
-    );
+    let totalVolunteerHoursByEventType = findTotalVolunteerHours(events, users, uniqueEventTypes, 'eventType');
     setVolunteeredHoursByEventType(totalVolunteerHoursByEventType);
-    let totalVolunteerHoursByHacknightProp = findTotalVolunteerHours(
-      events,
-      users,
-      hackNightUniqueLocations,
-      'hacknight'
-    );
+    let totalVolunteerHoursByHacknightProp = findTotalVolunteerHours(events, users, hackNightUniqueLocations, 'hacknight');
     setVolunteeredHoursByHacknightProp(totalVolunteerHoursByHacknightProp);
 
     //  Data for 3 chart 'total average hours'
     let totalVolunteerAvgHoursByEventType = findAverageVolunteerHours(
-      totalVolunteersByEventType,
-      totalVolunteerHoursByEventType,
-      uniqueEventTypes
-    );
+        totalVolunteersByEventType,
+        totalVolunteerHoursByEventType,
+        uniqueEventTypes);
     setAvgHoursByEventType(totalVolunteerAvgHoursByEventType);
 
     let totalVolunteerAvgHoursByHacknightProp = findAverageVolunteerHours(
-      totalVolunteersByHacknightProp,
-      totalVolunteerHoursByHacknightProp,
-      hackNightUniqueLocations
-    );
+        totalVolunteersByHacknightProp,
+        totalVolunteerHoursByHacknightProp,
+        hackNightUniqueLocations);
     setAvgHoursByHacknightProp(totalVolunteerAvgHoursByHacknightProp);
 
     // Display data by default for "All" chart type
@@ -191,26 +149,18 @@ const AdminDashboard = (props) => {
     setAvgHoursToChart(totalVolunteerAvgHoursByEventType);
   }
 
-  function extractVolunteersSignedInByProperty(
-    events,
-    users,
-    uniqueTypes,
-    propName
-  ) {
+  function extractVolunteersSignedInByProperty(events, users, uniqueTypes, propName){
     let result = {};
     let type;
 
-    uniqueTypes.forEach((el) => (result[el] = parseInt('0')));
+    uniqueTypes.forEach(el => result[el] = parseInt('0'));
     for (let eventId of users.keys()) {
-      if (propName === 'eventType') {
+      if(propName === 'eventType'){
         type = events.get(eventId).eventType;
         result[type] = users.get(eventId).length + result[type];
       }
 
-      if (
-        propName === 'hacknight' &&
-        typeof events.get(eventId).hacknight !== 'undefined'
-      ) {
+      if(propName === 'hacknight' && typeof events.get(eventId).hacknight !== 'undefined'){
         type = events.get(eventId).hacknight;
         result[type] = users.get(eventId).length + result[type];
       }
@@ -218,58 +168,46 @@ const AdminDashboard = (props) => {
     return result;
   }
 
-  function findTotalVolunteerHours(events, users, uniqueTypes, propName) {
+  function findTotalVolunteerHours(events, users, uniqueTypes, propName){
     let result = {};
     let type;
-    uniqueTypes.forEach((el) => (result[el] = parseInt('0')));
+    uniqueTypes.forEach(el => result[el] = parseInt('0'));
 
     for (let eventId of users.keys()) {
-      if (propName === 'eventType') {
+      if(propName === 'eventType'){
         type = events.get(eventId).eventType;
-        result[type] =
-          result[type] + events.get(eventId).hours * users.get(eventId).length;
+        result[type] = result[type] + (events.get(eventId).hours * users.get(eventId).length);
       }
 
-      if (
-        propName === 'hacknight' &&
-        typeof events.get(eventId).hacknight !== 'undefined'
-      ) {
+      if (propName === 'hacknight' && typeof events.get(eventId).hacknight !== 'undefined'){
         type = events.get(eventId).hacknight;
-        result[type] =
-          result[type] + events.get(eventId).hours * users.get(eventId).length;
+        result[type] = result[type] + (events.get(eventId).hours * users.get(eventId).length);
       }
     }
     return result;
   }
 
-  function findAverageVolunteerHours(
-    totalVolunteers,
-    totalVolunteerHours,
-    uniqueTypes
-  ) {
+  function findAverageVolunteerHours(totalVolunteers, totalVolunteerHours, uniqueTypes){
     let result = {};
-    uniqueTypes.forEach((el) => (result[el] = parseInt('0')));
+    uniqueTypes.forEach(el => result[el] = parseInt('0'));
 
-    for (let eventType of uniqueTypes.keys()) {
+    for(let eventType of uniqueTypes.keys()){
       let hours = totalVolunteerHours[eventType];
       let volunteers = totalVolunteers[eventType];
-      let averageHours = hours / volunteers;
-      if (!Number.isInteger(averageHours))
-        averageHours = +averageHours.toFixed(2);
-      volunteers > 0
-        ? (result[eventType] = averageHours)
-        : (result[eventType] = 0);
+      let averageHours = (hours / volunteers);
+      if(!Number.isInteger(averageHours)) averageHours = +averageHours.toFixed(2);
+      volunteers > 0 ? result[eventType] = averageHours : result[eventType] = 0;
     }
     return result;
   }
 
-  function setDonutCharts(valueFromSelect) {
+  function setDonutCharts(valueFromSelect){
     // Display data depending on value from select
-    if (valueFromSelect === defaultChartType) {
+    if(valueFromSelect === defaultChartType){
       setVolunteersToChart(totalVolunteersByEventType);
       setVolunteeredHoursToChart(totalVolunteerHoursByEventType);
       setAvgHoursToChart(totalVolunteerAvgHoursByEventType);
-    } else if (valueFromSelect === 'Hacknight Only') {
+    } else if (valueFromSelect === "Hacknight Only"){
       setVolunteersToChart(totalVolunteersByHacknightProp);
       setVolunteeredHoursToChart(totalVolunteerHoursByHacknightProp);
       setAvgHoursToChart(totalVolunteerAvgHoursByHacknightProp);
@@ -281,10 +219,10 @@ const AdminDashboard = (props) => {
 
     try {
       setIsLoading(true);
-      const users = await fetch('/api/users', {
+      const users = await fetch("/api/users", {
         headers: {
-          'Content-Type': 'application/json',
-          'x-customrequired-header': headerToSend,
+          "Content-Type": "application/json",
+          "x-customrequired-header": headerToSend,
         },
       });
       const usersJson = await users.json();
@@ -303,7 +241,7 @@ const AdminDashboard = (props) => {
     try {
       setIsLoading(true);
 
-      const events = await fetch('/api/events');
+      const events = await fetch("/api/events");
       const eventsJson = await events.json();
 
       const dates = eventsJson.map((event) => {
@@ -333,9 +271,9 @@ const AdminDashboard = (props) => {
 
     try {
       await fetch(`/api/events/${nextEventId}`, {
-        method: 'PATCH',
+        method: "PATCH",
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         },
       }).then((response) => {
         if (response.ok) {
@@ -359,64 +297,66 @@ const AdminDashboard = (props) => {
     getUsers();
   }, []);
 
-  return auth && auth.user ? (
-    <div className="flex-container">
-      <div className="dashboard">
-        <div className="dashboard-header">
-          <p className="dashboard-header-text-small">
-            You have an event coming up:
-          </p>
+  return (
+    auth && auth.user ? (
+      <div className="flex-container">
+        <div className="dashboard">
+          <div className="dashboard-header">
+            <p className="dashboard-header-text-small">
+              You have an event coming up:
+            </p>
+          </div>
+
+          {isLoading ? (
+              <Loading />
+          ) : (
+              <UpcomingEvent
+                  isCheckInReady={isCheckInReady}
+                  nextEvent={nextEvent}
+                  setCheckInReady={setCheckInReady}
+              />
+          )}
+
+          {isLoading ? (
+              <Loading />
+          ) : (
+              <EventOverview
+                  handleChartTypeChange={handleChartTypeChange}
+                  chartTypes={chartTypes}
+              />
+          )}
+
+          {isLoading ? (
+              <Loading />
+          ) : (
+              <DonutChartContainer
+                  chartName={"Total Volunteers"}
+                  data={totalVolunteers}
+              />
+          )}
+
+          {isLoading ? (
+              <Loading />
+          ) : (
+              <DonutChartContainer
+                  chartName={"Total Volunteer Hours"}
+                  data={totalVolunteerHours}
+              />
+          )}
+
+          {isLoading ? (
+              <Loading />
+          ) : (
+              <DonutChartContainer
+                  chartName={"Average Hours Per Volunteer"}
+                  data={totalVolunteerAvgHours}
+              />
+          )}
         </div>
-
-        {isLoading ? (
-          <Loading />
-        ) : (
-          <UpcomingEvent
-            isCheckInReady={isCheckInReady}
-            nextEvent={nextEvent}
-            setCheckInReady={setCheckInReady}
-          />
-        )}
-
-        {isLoading ? (
-          <Loading />
-        ) : (
-          <EventOverview
-            handleChartTypeChange={handleChartTypeChange}
-            chartTypes={chartTypes}
-          />
-        )}
-
-        {isLoading ? (
-          <Loading />
-        ) : (
-          <DonutChartContainer
-            chartName={'Total Volunteers'}
-            data={totalVolunteers}
-          />
-        )}
-
-        {isLoading ? (
-          <Loading />
-        ) : (
-          <DonutChartContainer
-            chartName={'Total Volunteer Hours'}
-            data={totalVolunteerHours}
-          />
-        )}
-
-        {isLoading ? (
-          <Loading />
-        ) : (
-          <DonutChartContainer
-            chartName={'Average Hours Per Volunteer'}
-            data={totalVolunteerAvgHours}
-          />
-        )}
       </div>
-    </div>
-  ) : (
-    <Redirect to="/login" />
+    ) : (
+        <Redirect to="/login" />
+    )
   );
 };
 

--- a/client/src/pages/AdminDashboard.js
+++ b/client/src/pages/AdminDashboard.js
@@ -12,10 +12,10 @@ import Loading from '../components/presentational/donutChartLoading';
 const AdminDashboard = (props) => {
   const auth = useAuth();
   const defaultChartType = 'All Events';
-  const uniqueEventTypes = new Set();
-  const hackNightUniqueLocations = new Set();
+  let uniqueEventTypes = new Set();
+  let hackNightUniqueLocations = new Set();
 
-  // STATE
+  //STATE
   const [nextEvent, setNextEvent] = useState([]);
   const [isCheckInReady, setIsCheckInReady] = useState();
   const [volunteers, setVolunteers] = useState(null);
@@ -74,15 +74,15 @@ const AdminDashboard = (props) => {
   }
 
   function processData(allEvents, allCheckIns) {
-    const processedEvents = processEvents(allEvents);
-    const usersByEvent = collectUsersByEvent(allCheckIns);
+    let processedEvents = processEvents(allEvents);
+    let usersByEvent = collectUsersByEvent(allCheckIns);
     prepareDataForCharts(processedEvents, usersByEvent);
   }
 
   function processEvents(allEvents) {
-    const events = new Map();
+    let events = new Map();
 
-    for (const event of allEvents) {
+    for (let event of allEvents) {
       // Process legacy data with undefined 'hours' property because initially an event length was 3 hours
       if (!event.hours) {
         event.hours = 3;
@@ -112,13 +112,13 @@ const AdminDashboard = (props) => {
         /(?:^|\s|["'([{])+\S/g,
         (match) => match.toUpperCase()
       );
-    const type = capitalize(event[propName], true);
+    let type = capitalize(event[propName], true);
     event[propName] = type;
     uniqueTypes.add(type);
   }
 
   function createChartTypes() {
-    const chartTypes = {
+    let chartTypes = {
       'All Events': '',
       'Hacknight Only': '',
     };
@@ -126,8 +126,8 @@ const AdminDashboard = (props) => {
   }
 
   function collectUsersByEvent(allCheckIns) {
-    const eventCollection = new Map();
-    for (const checkIn of allCheckIns) {
+    let eventCollection = new Map();
+    for (let checkIn of allCheckIns) {
       if (eventCollection.has(checkIn.eventId)) {
         eventCollection.get(checkIn.eventId).push(checkIn);
       } else {
@@ -139,14 +139,14 @@ const AdminDashboard = (props) => {
 
   function prepareDataForCharts(events, users) {
     // Data for 1 chart 'total volunteers'
-    const totalVolunteersByEventType = extractVolunteersSignedInByProperty(
+    let totalVolunteersByEventType = extractVolunteersSignedInByProperty(
       events,
       users,
       uniqueEventTypes,
       'eventType'
     );
     setVolunteersSignedInByEventType(totalVolunteersByEventType);
-    const totalVolunteersByHacknightProp = extractVolunteersSignedInByProperty(
+    let totalVolunteersByHacknightProp = extractVolunteersSignedInByProperty(
       events,
       users,
       hackNightUniqueLocations,
@@ -155,14 +155,14 @@ const AdminDashboard = (props) => {
     setVolunteersSignedInByHacknightProp(totalVolunteersByHacknightProp);
 
     // Data for 2 chart 'total hours'
-    const totalVolunteerHoursByEventType = findTotalVolunteerHours(
+    let totalVolunteerHoursByEventType = findTotalVolunteerHours(
       events,
       users,
       uniqueEventTypes,
       'eventType'
     );
     setVolunteeredHoursByEventType(totalVolunteerHoursByEventType);
-    const totalVolunteerHoursByHacknightProp = findTotalVolunteerHours(
+    let totalVolunteerHoursByHacknightProp = findTotalVolunteerHours(
       events,
       users,
       hackNightUniqueLocations,
@@ -171,14 +171,14 @@ const AdminDashboard = (props) => {
     setVolunteeredHoursByHacknightProp(totalVolunteerHoursByHacknightProp);
 
     //  Data for 3 chart 'total average hours'
-    const totalVolunteerAvgHoursByEventType = findAverageVolunteerHours(
+    let totalVolunteerAvgHoursByEventType = findAverageVolunteerHours(
       totalVolunteersByEventType,
       totalVolunteerHoursByEventType,
       uniqueEventTypes
     );
     setAvgHoursByEventType(totalVolunteerAvgHoursByEventType);
 
-    const totalVolunteerAvgHoursByHacknightProp = findAverageVolunteerHours(
+    let totalVolunteerAvgHoursByHacknightProp = findAverageVolunteerHours(
       totalVolunteersByHacknightProp,
       totalVolunteerHoursByHacknightProp,
       hackNightUniqueLocations
@@ -197,11 +197,11 @@ const AdminDashboard = (props) => {
     uniqueTypes,
     propName
   ) {
-    const result = {};
+    let result = {};
     let type;
 
     uniqueTypes.forEach((el) => (result[el] = parseInt('0')));
-    for (const eventId of users.keys()) {
+    for (let eventId of users.keys()) {
       if (propName === 'eventType') {
         type = events.get(eventId).eventType;
         result[type] = users.get(eventId).length + result[type];
@@ -219,11 +219,11 @@ const AdminDashboard = (props) => {
   }
 
   function findTotalVolunteerHours(events, users, uniqueTypes, propName) {
-    const result = {};
+    let result = {};
     let type;
     uniqueTypes.forEach((el) => (result[el] = parseInt('0')));
 
-    for (const eventId of users.keys()) {
+    for (let eventId of users.keys()) {
       if (propName === 'eventType') {
         type = events.get(eventId).eventType;
         result[type] =
@@ -247,12 +247,12 @@ const AdminDashboard = (props) => {
     totalVolunteerHours,
     uniqueTypes
   ) {
-    const result = {};
+    let result = {};
     uniqueTypes.forEach((el) => (result[el] = parseInt('0')));
 
-    for (const eventType of uniqueTypes.keys()) {
-      const hours = totalVolunteerHours[eventType];
-      const volunteers = totalVolunteers[eventType];
+    for (let eventType of uniqueTypes.keys()) {
+      let hours = totalVolunteerHours[eventType];
+      let volunteers = totalVolunteers[eventType];
       let averageHours = hours / volunteers;
       if (!Number.isInteger(averageHours))
         averageHours = +averageHours.toFixed(2);
@@ -391,7 +391,7 @@ const AdminDashboard = (props) => {
           <Loading />
         ) : (
           <DonutChartContainer
-            chartName="Total Volunteers"
+            chartName={'Total Volunteers'}
             data={totalVolunteers}
           />
         )}
@@ -400,7 +400,7 @@ const AdminDashboard = (props) => {
           <Loading />
         ) : (
           <DonutChartContainer
-            chartName="Total Volunteer Hours"
+            chartName={'Total Volunteer Hours'}
             data={totalVolunteerHours}
           />
         )}
@@ -409,7 +409,7 @@ const AdminDashboard = (props) => {
           <Loading />
         ) : (
           <DonutChartContainer
-            chartName="Average Hours Per Volunteer"
+            chartName={'Average Hours Per Volunteer'}
             data={totalVolunteerAvgHours}
           />
         )}

--- a/client/src/pages/AdminDashboard.js
+++ b/client/src/pages/AdminDashboard.js
@@ -12,10 +12,10 @@ import Loading from '../components/presentational/donutChartLoading';
 const AdminDashboard = (props) => {
   const auth = useAuth();
   const defaultChartType = 'All Events';
-  let uniqueEventTypes = new Set();
-  let hackNightUniqueLocations = new Set();
+  const uniqueEventTypes = new Set();
+  const hackNightUniqueLocations = new Set();
 
-  //STATE
+  // STATE
   const [nextEvent, setNextEvent] = useState([]);
   const [isCheckInReady, setIsCheckInReady] = useState();
   const [volunteers, setVolunteers] = useState(null);
@@ -74,15 +74,15 @@ const AdminDashboard = (props) => {
   }
 
   function processData(allEvents, allCheckIns) {
-    let processedEvents = processEvents(allEvents);
-    let usersByEvent = collectUsersByEvent(allCheckIns);
+    const processedEvents = processEvents(allEvents);
+    const usersByEvent = collectUsersByEvent(allCheckIns);
     prepareDataForCharts(processedEvents, usersByEvent);
   }
 
   function processEvents(allEvents) {
-    let events = new Map();
+    const events = new Map();
 
-    for (let event of allEvents) {
+    for (const event of allEvents) {
       // Process legacy data with undefined 'hours' property because initially an event length was 3 hours
       if (!event.hours) {
         event.hours = 3;
@@ -112,13 +112,13 @@ const AdminDashboard = (props) => {
         /(?:^|\s|["'([{])+\S/g,
         (match) => match.toUpperCase()
       );
-    let type = capitalize(event[propName], true);
+    const type = capitalize(event[propName], true);
     event[propName] = type;
     uniqueTypes.add(type);
   }
 
   function createChartTypes() {
-    let chartTypes = {
+    const chartTypes = {
       'All Events': '',
       'Hacknight Only': '',
     };
@@ -126,8 +126,8 @@ const AdminDashboard = (props) => {
   }
 
   function collectUsersByEvent(allCheckIns) {
-    let eventCollection = new Map();
-    for (let checkIn of allCheckIns) {
+    const eventCollection = new Map();
+    for (const checkIn of allCheckIns) {
       if (eventCollection.has(checkIn.eventId)) {
         eventCollection.get(checkIn.eventId).push(checkIn);
       } else {
@@ -139,14 +139,14 @@ const AdminDashboard = (props) => {
 
   function prepareDataForCharts(events, users) {
     // Data for 1 chart 'total volunteers'
-    let totalVolunteersByEventType = extractVolunteersSignedInByProperty(
+    const totalVolunteersByEventType = extractVolunteersSignedInByProperty(
       events,
       users,
       uniqueEventTypes,
       'eventType'
     );
     setVolunteersSignedInByEventType(totalVolunteersByEventType);
-    let totalVolunteersByHacknightProp = extractVolunteersSignedInByProperty(
+    const totalVolunteersByHacknightProp = extractVolunteersSignedInByProperty(
       events,
       users,
       hackNightUniqueLocations,
@@ -155,14 +155,14 @@ const AdminDashboard = (props) => {
     setVolunteersSignedInByHacknightProp(totalVolunteersByHacknightProp);
 
     // Data for 2 chart 'total hours'
-    let totalVolunteerHoursByEventType = findTotalVolunteerHours(
+    const totalVolunteerHoursByEventType = findTotalVolunteerHours(
       events,
       users,
       uniqueEventTypes,
       'eventType'
     );
     setVolunteeredHoursByEventType(totalVolunteerHoursByEventType);
-    let totalVolunteerHoursByHacknightProp = findTotalVolunteerHours(
+    const totalVolunteerHoursByHacknightProp = findTotalVolunteerHours(
       events,
       users,
       hackNightUniqueLocations,
@@ -171,14 +171,14 @@ const AdminDashboard = (props) => {
     setVolunteeredHoursByHacknightProp(totalVolunteerHoursByHacknightProp);
 
     //  Data for 3 chart 'total average hours'
-    let totalVolunteerAvgHoursByEventType = findAverageVolunteerHours(
+    const totalVolunteerAvgHoursByEventType = findAverageVolunteerHours(
       totalVolunteersByEventType,
       totalVolunteerHoursByEventType,
       uniqueEventTypes
     );
     setAvgHoursByEventType(totalVolunteerAvgHoursByEventType);
 
-    let totalVolunteerAvgHoursByHacknightProp = findAverageVolunteerHours(
+    const totalVolunteerAvgHoursByHacknightProp = findAverageVolunteerHours(
       totalVolunteersByHacknightProp,
       totalVolunteerHoursByHacknightProp,
       hackNightUniqueLocations
@@ -197,11 +197,11 @@ const AdminDashboard = (props) => {
     uniqueTypes,
     propName
   ) {
-    let result = {};
+    const result = {};
     let type;
 
     uniqueTypes.forEach((el) => (result[el] = parseInt('0')));
-    for (let eventId of users.keys()) {
+    for (const eventId of users.keys()) {
       if (propName === 'eventType') {
         type = events.get(eventId).eventType;
         result[type] = users.get(eventId).length + result[type];
@@ -219,11 +219,11 @@ const AdminDashboard = (props) => {
   }
 
   function findTotalVolunteerHours(events, users, uniqueTypes, propName) {
-    let result = {};
+    const result = {};
     let type;
     uniqueTypes.forEach((el) => (result[el] = parseInt('0')));
 
-    for (let eventId of users.keys()) {
+    for (const eventId of users.keys()) {
       if (propName === 'eventType') {
         type = events.get(eventId).eventType;
         result[type] =
@@ -247,12 +247,12 @@ const AdminDashboard = (props) => {
     totalVolunteerHours,
     uniqueTypes
   ) {
-    let result = {};
+    const result = {};
     uniqueTypes.forEach((el) => (result[el] = parseInt('0')));
 
-    for (let eventType of uniqueTypes.keys()) {
-      let hours = totalVolunteerHours[eventType];
-      let volunteers = totalVolunteers[eventType];
+    for (const eventType of uniqueTypes.keys()) {
+      const hours = totalVolunteerHours[eventType];
+      const volunteers = totalVolunteers[eventType];
       let averageHours = hours / volunteers;
       if (!Number.isInteger(averageHours))
         averageHours = +averageHours.toFixed(2);
@@ -391,7 +391,7 @@ const AdminDashboard = (props) => {
           <Loading />
         ) : (
           <DonutChartContainer
-            chartName={'Total Volunteers'}
+            chartName="Total Volunteers"
             data={totalVolunteers}
           />
         )}
@@ -400,7 +400,7 @@ const AdminDashboard = (props) => {
           <Loading />
         ) : (
           <DonutChartContainer
-            chartName={'Total Volunteer Hours'}
+            chartName="Total Volunteer Hours"
             data={totalVolunteerHours}
           />
         )}
@@ -409,7 +409,7 @@ const AdminDashboard = (props) => {
           <Loading />
         ) : (
           <DonutChartContainer
-            chartName={'Average Hours Per Volunteer'}
+            chartName="Average Hours Per Volunteer"
             data={totalVolunteerAvgHours}
           />
         )}

--- a/client/src/pages/AdminDashboard.js
+++ b/client/src/pages/AdminDashboard.js
@@ -1,17 +1,17 @@
-import React, { useState, useEffect } from "react";
-import { Redirect } from "react-router-dom";
+import React, { useState, useEffect } from 'react';
+import { Redirect } from 'react-router-dom';
 
-import useAuth from "../hooks/useAuth";
+import useAuth from '../hooks/useAuth';
 
-import "../sass/Dashboard.scss";
-import UpcomingEvent from "../components/presentational/upcomingEvent";
-import EventOverview from "../components/presentational/eventOverview";
-import DonutChartContainer from "../components/presentational/donutChartContainer";
-import Loading from "../components/presentational/donutChartLoading";
+import '../sass/Dashboard.scss';
+import UpcomingEvent from '../components/presentational/upcomingEvent';
+import EventOverview from '../components/presentational/eventOverview';
+import DonutChartContainer from '../components/presentational/donutChartContainer';
+import Loading from '../components/presentational/donutChartLoading';
 
 const AdminDashboard = (props) => {
   const auth = useAuth();
-  const defaultChartType = "All Events";
+  const defaultChartType = 'All Events';
   let uniqueEventTypes = new Set();
   let hackNightUniqueLocations = new Set();
 
@@ -24,14 +24,31 @@ const AdminDashboard = (props) => {
   const [chartTypes, setChartTypes] = useState(null);
 
   // Volunteers SignedIn By Event Type
-  const [totalVolunteersByEventType, setVolunteersSignedInByEventType] = useState({});
-  const [totalVolunteerHoursByEventType, setVolunteeredHoursByEventType] = useState({});
-  const [totalVolunteerAvgHoursByEventType, setAvgHoursByEventType] = useState({});
+  const [
+    totalVolunteersByEventType,
+    setVolunteersSignedInByEventType,
+  ] = useState({});
+  const [
+    totalVolunteerHoursByEventType,
+    setVolunteeredHoursByEventType,
+  ] = useState({});
+  const [totalVolunteerAvgHoursByEventType, setAvgHoursByEventType] = useState(
+    {}
+  );
 
   // Volunteers SignedIn By Hacknight Property
-  const [totalVolunteersByHacknightProp, setVolunteersSignedInByHacknightProp] = useState({});
-  const [totalVolunteerHoursByHacknightProp, setVolunteeredHoursByHacknightProp] = useState({});
-  const [totalVolunteerAvgHoursByHacknightProp, setAvgHoursByHacknightProp] = useState({});
+  const [
+    totalVolunteersByHacknightProp,
+    setVolunteersSignedInByHacknightProp,
+  ] = useState({});
+  const [
+    totalVolunteerHoursByHacknightProp,
+    setVolunteeredHoursByHacknightProp,
+  ] = useState({});
+  const [
+    totalVolunteerAvgHoursByHacknightProp,
+    setAvgHoursByHacknightProp,
+  ] = useState({});
 
   // Volunteers To Chart
   const [totalVolunteers, setVolunteersToChart] = useState({});
@@ -43,9 +60,9 @@ const AdminDashboard = (props) => {
   async function getAndSetData() {
     try {
       setIsLoading(true);
-      const checkIns = await fetch("/api/checkins");
+      const checkIns = await fetch('/api/checkins');
       const checkInsJson = await checkIns.json();
-      const events = await fetch("/api/events");
+      const events = await fetch('/api/events');
       const eventsJson = await events.json();
 
       processData(eventsJson, checkInsJson);
@@ -56,7 +73,7 @@ const AdminDashboard = (props) => {
     }
   }
 
-  function processData(allEvents, allCheckIns){
+  function processData(allEvents, allCheckIns) {
     let processedEvents = processEvents(allEvents);
     let usersByEvent = collectUsersByEvent(allCheckIns);
     prepareDataForCharts(processedEvents, usersByEvent);
@@ -65,14 +82,14 @@ const AdminDashboard = (props) => {
   function processEvents(allEvents) {
     let events = new Map();
 
-    for (let event of allEvents){
+    for (let event of allEvents) {
       // Process legacy data with undefined 'hours' property because initially an event length was 3 hours
-      if(!event.hours){
+      if (!event.hours) {
         event.hours = 3;
       }
 
       // Define unique event types and process events without 'eventType' property
-      if(event.eventType){
+      if (event.eventType) {
         processEventTypes(event, 'eventType', uniqueEventTypes);
       } else {
         // Find events without 'eventType' property (30 events) and assign it
@@ -80,7 +97,7 @@ const AdminDashboard = (props) => {
       }
 
       // Extract events with 'hacknight' property & find unique locations in it
-      if(event.hacknight){
+      if (event.hacknight) {
         processEventTypes(event, 'hacknight', hackNightUniqueLocations);
       }
       events.set(event._id, event);
@@ -89,58 +106,83 @@ const AdminDashboard = (props) => {
     return events;
   }
 
-  function processEventTypes(event, propName, uniqueTypes){
+  function processEventTypes(event, propName, uniqueTypes) {
     const capitalize = (str, lower = false) =>
-        (lower ? str.toLowerCase() : str).replace(/(?:^|\s|["'([{])+\S/g, match => match.toUpperCase());
+      (lower ? str.toLowerCase() : str).replace(
+        /(?:^|\s|["'([{])+\S/g,
+        (match) => match.toUpperCase()
+      );
     let type = capitalize(event[propName], true);
     event[propName] = type;
     uniqueTypes.add(type);
   }
 
-  function createChartTypes(){
+  function createChartTypes() {
     let chartTypes = {
-      "All Events": "",
-      "Hacknight Only": ""
+      'All Events': '',
+      'Hacknight Only': '',
     };
     setChartTypes(chartTypes);
   }
 
-  function collectUsersByEvent(allCheckIns){
+  function collectUsersByEvent(allCheckIns) {
     let eventCollection = new Map();
-    for(let checkIn of allCheckIns){
-      if(eventCollection.has(checkIn.eventId)){
+    for (let checkIn of allCheckIns) {
+      if (eventCollection.has(checkIn.eventId)) {
         eventCollection.get(checkIn.eventId).push(checkIn);
-      } else{
+      } else {
         eventCollection.set(checkIn.eventId, [checkIn]);
       }
     }
     return eventCollection;
   }
 
-  function prepareDataForCharts(events, users){
+  function prepareDataForCharts(events, users) {
     // Data for 1 chart 'total volunteers'
-    let totalVolunteersByEventType = extractVolunteersSignedInByProperty(events, users, uniqueEventTypes, 'eventType');
+    let totalVolunteersByEventType = extractVolunteersSignedInByProperty(
+      events,
+      users,
+      uniqueEventTypes,
+      'eventType'
+    );
     setVolunteersSignedInByEventType(totalVolunteersByEventType);
-    let totalVolunteersByHacknightProp = extractVolunteersSignedInByProperty(events, users, hackNightUniqueLocations, 'hacknight');
+    let totalVolunteersByHacknightProp = extractVolunteersSignedInByProperty(
+      events,
+      users,
+      hackNightUniqueLocations,
+      'hacknight'
+    );
     setVolunteersSignedInByHacknightProp(totalVolunteersByHacknightProp);
 
     // Data for 2 chart 'total hours'
-    let totalVolunteerHoursByEventType = findTotalVolunteerHours(events, users, uniqueEventTypes, 'eventType');
+    let totalVolunteerHoursByEventType = findTotalVolunteerHours(
+      events,
+      users,
+      uniqueEventTypes,
+      'eventType'
+    );
     setVolunteeredHoursByEventType(totalVolunteerHoursByEventType);
-    let totalVolunteerHoursByHacknightProp = findTotalVolunteerHours(events, users, hackNightUniqueLocations, 'hacknight');
+    let totalVolunteerHoursByHacknightProp = findTotalVolunteerHours(
+      events,
+      users,
+      hackNightUniqueLocations,
+      'hacknight'
+    );
     setVolunteeredHoursByHacknightProp(totalVolunteerHoursByHacknightProp);
 
     //  Data for 3 chart 'total average hours'
     let totalVolunteerAvgHoursByEventType = findAverageVolunteerHours(
-        totalVolunteersByEventType,
-        totalVolunteerHoursByEventType,
-        uniqueEventTypes);
+      totalVolunteersByEventType,
+      totalVolunteerHoursByEventType,
+      uniqueEventTypes
+    );
     setAvgHoursByEventType(totalVolunteerAvgHoursByEventType);
 
     let totalVolunteerAvgHoursByHacknightProp = findAverageVolunteerHours(
-        totalVolunteersByHacknightProp,
-        totalVolunteerHoursByHacknightProp,
-        hackNightUniqueLocations);
+      totalVolunteersByHacknightProp,
+      totalVolunteerHoursByHacknightProp,
+      hackNightUniqueLocations
+    );
     setAvgHoursByHacknightProp(totalVolunteerAvgHoursByHacknightProp);
 
     // Display data by default for "All" chart type
@@ -149,18 +191,26 @@ const AdminDashboard = (props) => {
     setAvgHoursToChart(totalVolunteerAvgHoursByEventType);
   }
 
-  function extractVolunteersSignedInByProperty(events, users, uniqueTypes, propName){
+  function extractVolunteersSignedInByProperty(
+    events,
+    users,
+    uniqueTypes,
+    propName
+  ) {
     let result = {};
     let type;
 
-    uniqueTypes.forEach(el => result[el] = parseInt('0'));
+    uniqueTypes.forEach((el) => (result[el] = parseInt('0')));
     for (let eventId of users.keys()) {
-      if(propName === 'eventType'){
+      if (propName === 'eventType') {
         type = events.get(eventId).eventType;
         result[type] = users.get(eventId).length + result[type];
       }
 
-      if(propName === 'hacknight' && typeof events.get(eventId).hacknight !== 'undefined'){
+      if (
+        propName === 'hacknight' &&
+        typeof events.get(eventId).hacknight !== 'undefined'
+      ) {
         type = events.get(eventId).hacknight;
         result[type] = users.get(eventId).length + result[type];
       }
@@ -168,46 +218,58 @@ const AdminDashboard = (props) => {
     return result;
   }
 
-  function findTotalVolunteerHours(events, users, uniqueTypes, propName){
+  function findTotalVolunteerHours(events, users, uniqueTypes, propName) {
     let result = {};
     let type;
-    uniqueTypes.forEach(el => result[el] = parseInt('0'));
+    uniqueTypes.forEach((el) => (result[el] = parseInt('0')));
 
     for (let eventId of users.keys()) {
-      if(propName === 'eventType'){
+      if (propName === 'eventType') {
         type = events.get(eventId).eventType;
-        result[type] = result[type] + (events.get(eventId).hours * users.get(eventId).length);
+        result[type] =
+          result[type] + events.get(eventId).hours * users.get(eventId).length;
       }
 
-      if (propName === 'hacknight' && typeof events.get(eventId).hacknight !== 'undefined'){
+      if (
+        propName === 'hacknight' &&
+        typeof events.get(eventId).hacknight !== 'undefined'
+      ) {
         type = events.get(eventId).hacknight;
-        result[type] = result[type] + (events.get(eventId).hours * users.get(eventId).length);
+        result[type] =
+          result[type] + events.get(eventId).hours * users.get(eventId).length;
       }
     }
     return result;
   }
 
-  function findAverageVolunteerHours(totalVolunteers, totalVolunteerHours, uniqueTypes){
+  function findAverageVolunteerHours(
+    totalVolunteers,
+    totalVolunteerHours,
+    uniqueTypes
+  ) {
     let result = {};
-    uniqueTypes.forEach(el => result[el] = parseInt('0'));
+    uniqueTypes.forEach((el) => (result[el] = parseInt('0')));
 
-    for(let eventType of uniqueTypes.keys()){
+    for (let eventType of uniqueTypes.keys()) {
       let hours = totalVolunteerHours[eventType];
       let volunteers = totalVolunteers[eventType];
-      let averageHours = (hours / volunteers);
-      if(!Number.isInteger(averageHours)) averageHours = +averageHours.toFixed(2);
-      volunteers > 0 ? result[eventType] = averageHours : result[eventType] = 0;
+      let averageHours = hours / volunteers;
+      if (!Number.isInteger(averageHours))
+        averageHours = +averageHours.toFixed(2);
+      volunteers > 0
+        ? (result[eventType] = averageHours)
+        : (result[eventType] = 0);
     }
     return result;
   }
 
-  function setDonutCharts(valueFromSelect){
+  function setDonutCharts(valueFromSelect) {
     // Display data depending on value from select
-    if(valueFromSelect === defaultChartType){
+    if (valueFromSelect === defaultChartType) {
       setVolunteersToChart(totalVolunteersByEventType);
       setVolunteeredHoursToChart(totalVolunteerHoursByEventType);
       setAvgHoursToChart(totalVolunteerAvgHoursByEventType);
-    } else if (valueFromSelect === "Hacknight Only"){
+    } else if (valueFromSelect === 'Hacknight Only') {
       setVolunteersToChart(totalVolunteersByHacknightProp);
       setVolunteeredHoursToChart(totalVolunteerHoursByHacknightProp);
       setAvgHoursToChart(totalVolunteerAvgHoursByHacknightProp);
@@ -219,10 +281,10 @@ const AdminDashboard = (props) => {
 
     try {
       setIsLoading(true);
-      const users = await fetch("/api/users", {
+      const users = await fetch('/api/users', {
         headers: {
-          "Content-Type": "application/json",
-          "x-customrequired-header": headerToSend,
+          'Content-Type': 'application/json',
+          'x-customrequired-header': headerToSend,
         },
       });
       const usersJson = await users.json();
@@ -241,7 +303,7 @@ const AdminDashboard = (props) => {
     try {
       setIsLoading(true);
 
-      const events = await fetch("/api/events");
+      const events = await fetch('/api/events');
       const eventsJson = await events.json();
 
       const dates = eventsJson.map((event) => {
@@ -271,9 +333,9 @@ const AdminDashboard = (props) => {
 
     try {
       await fetch(`/api/events/${nextEventId}`, {
-        method: "PATCH",
+        method: 'PATCH',
         headers: {
-          "Content-Type": "application/json",
+          'Content-Type': 'application/json',
         },
       }).then((response) => {
         if (response.ok) {
@@ -297,66 +359,64 @@ const AdminDashboard = (props) => {
     getUsers();
   }, []);
 
-  return (
-    auth && auth.user ? (
-      <div className="flex-container">
-        <div className="dashboard">
-          <div className="dashboard-header">
-            <p className="dashboard-header-text-small">
-              You have an event coming up:
-            </p>
-          </div>
-
-          {isLoading ? (
-              <Loading />
-          ) : (
-              <UpcomingEvent
-                  isCheckInReady={isCheckInReady}
-                  nextEvent={nextEvent}
-                  setCheckInReady={setCheckInReady}
-              />
-          )}
-
-          {isLoading ? (
-              <Loading />
-          ) : (
-              <EventOverview
-                  handleChartTypeChange={handleChartTypeChange}
-                  chartTypes={chartTypes}
-              />
-          )}
-
-          {isLoading ? (
-              <Loading />
-          ) : (
-              <DonutChartContainer
-                  chartName={"Total Volunteers"}
-                  data={totalVolunteers}
-              />
-          )}
-
-          {isLoading ? (
-              <Loading />
-          ) : (
-              <DonutChartContainer
-                  chartName={"Total Volunteer Hours"}
-                  data={totalVolunteerHours}
-              />
-          )}
-
-          {isLoading ? (
-              <Loading />
-          ) : (
-              <DonutChartContainer
-                  chartName={"Average Hours Per Volunteer"}
-                  data={totalVolunteerAvgHours}
-              />
-          )}
+  return auth && auth.user ? (
+    <div className="flex-container">
+      <div className="dashboard">
+        <div className="dashboard-header">
+          <p className="dashboard-header-text-small">
+            You have an event coming up:
+          </p>
         </div>
+
+        {isLoading ? (
+          <Loading />
+        ) : (
+          <UpcomingEvent
+            isCheckInReady={isCheckInReady}
+            nextEvent={nextEvent}
+            setCheckInReady={setCheckInReady}
+          />
+        )}
+
+        {isLoading ? (
+          <Loading />
+        ) : (
+          <EventOverview
+            handleChartTypeChange={handleChartTypeChange}
+            chartTypes={chartTypes}
+          />
+        )}
+
+        {isLoading ? (
+          <Loading />
+        ) : (
+          <DonutChartContainer
+            chartName={'Total Volunteers'}
+            data={totalVolunteers}
+          />
+        )}
+
+        {isLoading ? (
+          <Loading />
+        ) : (
+          <DonutChartContainer
+            chartName={'Total Volunteer Hours'}
+            data={totalVolunteerHours}
+          />
+        )}
+
+        {isLoading ? (
+          <Loading />
+        ) : (
+          <DonutChartContainer
+            chartName={'Average Hours Per Volunteer'}
+            data={totalVolunteerAvgHours}
+          />
+        )}
       </div>
-    ) : (
-        <Redirect to="/login" />
-    )
+    </div>
+  ) : (
+    <Redirect to="/login" />
   );
 };
 

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1166,6 +1166,22 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
+"@eslint/eslintrc@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.1.3.tgz#7d1a2b2358552cc04834c0979bd4275362e37085"
+  integrity sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==
+  dependencies:
+    ajv "^6.12.4"
+    debug "^4.1.1"
+    espree "^7.3.0"
+    globals "^12.1.0"
+    ignore "^4.0.6"
+    import-fresh "^3.2.1"
+    js-yaml "^3.13.1"
+    lodash "^4.17.19"
+    minimatch "^3.0.4"
+    strip-json-comments "^3.1.1"
+
 "@firebase/analytics-types@0.3.1":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@firebase/analytics-types/-/analytics-types-0.3.1.tgz#3c5f5d71129c88295e17e914e34b391ffda1723c"
@@ -1851,6 +1867,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
   integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
 
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
 "@types/long@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
@@ -2155,7 +2176,7 @@ acorn@^6.0.1, acorn@^6.0.4, acorn@^6.2.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
   integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
 
-acorn@^7.1.1:
+acorn@^7.1.1, acorn@^7.4.0:
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.0.tgz#e1ad486e6c54501634c6c397c5c121daa383607c"
   integrity sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==
@@ -2211,6 +2232,16 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.12.3:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ajv@^6.12.4:
+  version "6.12.5"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.5.tgz#19b0e8bae8f476e5ba666300387775fb1a00a4da"
+  integrity sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
 alphanum-sort@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
@@ -2225,6 +2256,11 @@ ansi-colors@^3.0.0:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
   integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
+
+ansi-colors@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
+  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
 
 ansi-escapes@^3.0.0:
   version "3.2.0"
@@ -2393,7 +2429,7 @@ array-unique@^0.3.2:
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
-array.prototype.flat@^1.2.1:
+array.prototype.flat@^1.2.1, array.prototype.flat@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz#0de82b426b0318dbfdb940089e38b043d37f6c7b"
   integrity sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==
@@ -3791,7 +3827,7 @@ chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
@@ -4301,7 +4337,7 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.1:
+cross-spawn@^7.0.1, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -4891,7 +4927,7 @@ deep-equal@^1.0.1:
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
 
-deep-is@~0.1.3:
+deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
@@ -5264,6 +5300,13 @@ enhanced-resolve@^4.1.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
+enquirer@^2.3.5:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
+  integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
+  dependencies:
+    ansi-colors "^4.1.1"
+
 entities@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
@@ -5395,6 +5438,22 @@ escodegen@^1.11.0, escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-config-airbnb-base@^14.2.0:
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.0.tgz#fe89c24b3f9dc8008c9c0d0d88c28f95ed65e9c4"
+  integrity sha512-Snswd5oC6nJaevs3nZoLSTvGJBvzTfnBqOIArkf3cbyTyq9UD79wOk8s+RiL6bhca0p/eRO6veczhf6A/7Jy8Q==
+  dependencies:
+    confusing-browser-globals "^1.0.9"
+    object.assign "^4.1.0"
+    object.entries "^1.1.2"
+
+eslint-config-prettier@^6.11.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz#f6d2238c1290d01c859a8b5c1f7d352a0b0da8b1"
+  integrity sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==
+  dependencies:
+    get-stdin "^6.0.0"
+
 eslint-config-react-app@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-5.2.1.tgz#698bf7aeee27f0cea0139eaef261c7bf7dd623df"
@@ -5402,7 +5461,7 @@ eslint-config-react-app@^5.2.1:
   dependencies:
     confusing-browser-globals "^1.0.9"
 
-eslint-import-resolver-node@^0.3.2:
+eslint-import-resolver-node@^0.3.2, eslint-import-resolver-node@^0.3.3:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz#85ffa81942c25012d8231096ddf679c03042c717"
   integrity sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==
@@ -5421,7 +5480,7 @@ eslint-loader@3.0.3:
     object-hash "^2.0.1"
     schema-utils "^2.6.1"
 
-eslint-module-utils@^2.4.1:
+eslint-module-utils@^2.4.1, eslint-module-utils@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz#579ebd094f56af7797d19c9866c9c9486629bfa6"
   integrity sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==
@@ -5454,6 +5513,25 @@ eslint-plugin-import@2.20.1:
     read-pkg-up "^2.0.0"
     resolve "^1.12.0"
 
+eslint-plugin-import@^2.22.0:
+  version "2.22.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz#92f7736fe1fde3e2de77623c838dd992ff5ffb7e"
+  integrity sha512-66Fpf1Ln6aIS5Gr/55ts19eUuoDhAbZgnr6UxK5hbDx6l/QgQgx61AePq+BV4PP2uXQFClgMVzep5zZ94qqsxg==
+  dependencies:
+    array-includes "^3.1.1"
+    array.prototype.flat "^1.2.3"
+    contains-path "^0.1.0"
+    debug "^2.6.9"
+    doctrine "1.5.0"
+    eslint-import-resolver-node "^0.3.3"
+    eslint-module-utils "^2.6.0"
+    has "^1.0.3"
+    minimatch "^3.0.4"
+    object.values "^1.1.1"
+    read-pkg-up "^2.0.0"
+    resolve "^1.17.0"
+    tsconfig-paths "^3.9.0"
+
 eslint-plugin-jsx-a11y@6.2.3:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz#b872a09d5de51af70a97db1eea7dc933043708aa"
@@ -5469,10 +5547,22 @@ eslint-plugin-jsx-a11y@6.2.3:
     has "^1.0.3"
     jsx-ast-utils "^2.2.1"
 
+eslint-plugin-prettier@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz#168ab43154e2ea57db992a2cd097c828171f75c2"
+  integrity sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
 eslint-plugin-react-hooks@^1.6.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz#6210b6d5a37205f0b92858f895a4e827020a7d04"
   integrity sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==
+
+eslint-plugin-react-hooks@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.1.2.tgz#2eb53731d11c95826ef7a7272303eabb5c9a271e"
+  integrity sha512-ykUeqkGyUGgwTtk78C0o8UG2fzwmgJ0qxBGPp2WqRKsTwcLuVf01kTDRAtOsd4u6whX2XOC8749n2vPydP82fg==
 
 eslint-plugin-react@7.19.0:
   version "7.19.0"
@@ -5508,6 +5598,14 @@ eslint-scope@^5.0.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-scope@^5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
+  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
+  dependencies:
+    esrecurse "^4.3.0"
+    estraverse "^4.1.1"
+
 eslint-utils@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
@@ -5515,14 +5613,14 @@ eslint-utils@^1.4.3:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-utils@^2.0.0:
+eslint-utils@^2.0.0, eslint-utils@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
   integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
+eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
@@ -5570,6 +5668,49 @@ eslint@^6.6.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
+eslint@^7.9.0:
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.9.0.tgz#522aeccc5c3a19017cf0cb46ebfd660a79acf337"
+  integrity sha512-V6QyhX21+uXp4T+3nrNfI3hQNBDa/P8ga7LoQOenwrlEFXrEnUEE+ok1dMtaS3b6rmLXhT1TkTIsG75HMLbknA==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@eslint/eslintrc" "^0.1.3"
+    ajv "^6.10.0"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.2"
+    debug "^4.0.1"
+    doctrine "^3.0.0"
+    enquirer "^2.3.5"
+    eslint-scope "^5.1.0"
+    eslint-utils "^2.1.0"
+    eslint-visitor-keys "^1.3.0"
+    espree "^7.3.0"
+    esquery "^1.2.0"
+    esutils "^2.0.2"
+    file-entry-cache "^5.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob-parent "^5.0.0"
+    globals "^12.1.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    is-glob "^4.0.0"
+    js-yaml "^3.13.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.4.1"
+    lodash "^4.17.19"
+    minimatch "^3.0.4"
+    natural-compare "^1.4.0"
+    optionator "^0.9.1"
+    progress "^2.0.0"
+    regexpp "^3.1.0"
+    semver "^7.2.1"
+    strip-ansi "^6.0.0"
+    strip-json-comments "^3.1.0"
+    table "^5.2.3"
+    text-table "^0.2.0"
+    v8-compile-cache "^2.0.3"
+
 espree@^6.1.2:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-6.2.1.tgz#77fc72e1fd744a2052c20f38a5b575832e82734a"
@@ -5579,12 +5720,21 @@ espree@^6.1.2:
     acorn-jsx "^5.2.0"
     eslint-visitor-keys "^1.1.0"
 
+espree@^7.3.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.0.tgz#dc30437cf67947cf576121ebd780f15eeac72348"
+  integrity sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==
+  dependencies:
+    acorn "^7.4.0"
+    acorn-jsx "^5.2.0"
+    eslint-visitor-keys "^1.3.0"
+
 esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.0.1:
+esquery@^1.0.1, esquery@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.3.1.tgz#b78b5828aa8e214e29fb74c4d5b752e1c033da57"
   integrity sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==
@@ -5598,12 +5748,19 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "^4.1.0"
 
+esrecurse@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
+  integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
+  dependencies:
+    estraverse "^5.2.0"
+
 estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
-estraverse@^5.1.0:
+estraverse@^5.1.0, estraverse@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
@@ -5797,6 +5954,11 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
+
 fast-glob@^2.0.2:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.7.tgz#6953857c3afa475fff92ee6015d52da70a4cd39d"
@@ -5814,7 +5976,7 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-fast-levenshtein@~2.0.6:
+fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
@@ -6242,6 +6404,11 @@ get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
   integrity sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=
+
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
+  integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
 
 get-stream@^4.0.0:
   version "4.1.0"
@@ -6812,7 +6979,7 @@ import-fresh@^2.0.0:
     caller-path "^2.0.0"
     resolve-from "^3.0.0"
 
-import-fresh@^3.0.0, import-fresh@^3.1.0:
+import-fresh@^3.0.0, import-fresh@^3.1.0, import-fresh@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
   integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
@@ -8078,6 +8245,14 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+levn@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
+  integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
+  dependencies:
+    prelude-ls "^1.2.1"
+    type-check "~0.4.0"
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -8972,7 +9147,7 @@ object.assign@^4.1.0:
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
 
-object.entries@^1.1.0, object.entries@^1.1.1:
+object.entries@^1.1.0, object.entries@^1.1.1, object.entries@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.2.tgz#bc73f00acb6b6bb16c203434b10f9a7e797d3add"
   integrity sha512-BQdB9qKmb/HyNdMNWVr7O3+z5MUIx3aiegEIJqjMBbBf0YT9RRxTJSim4mzFqtyr7PDAHigq0N9dO0m0tRakQA==
@@ -9081,6 +9256,18 @@ optionator@^0.8.1, optionator@^0.8.3:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
     word-wrap "~1.2.3"
+
+optionator@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
+  integrity sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==
+  dependencies:
+    deep-is "^0.1.3"
+    fast-levenshtein "^2.0.6"
+    levn "^0.4.1"
+    prelude-ls "^1.2.1"
+    type-check "^0.4.0"
+    word-wrap "^1.2.3"
 
 original@^1.0.0:
   version "1.0.2"
@@ -10155,6 +10342,11 @@ postcss@^7, postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, po
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
+prelude-ls@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
+  integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -10164,6 +10356,18 @@ prepend-http@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
+prettier@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
+  integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
 
 pretty-bytes@^5.1.0:
   version "5.3.0"
@@ -10756,7 +10960,7 @@ regexpp@^2.0.1:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
 
-regexpp@^3.0.0:
+regexpp@^3.0.0, regexpp@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
   integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
@@ -10956,7 +11160,7 @@ resolve@1.15.0:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.3.2, resolve@^1.8.1:
+resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.8.1:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
@@ -11196,7 +11400,7 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@^7.3.2:
+semver@^7.2.1, semver@^7.3.2:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
@@ -11829,7 +12033,7 @@ strip-indent@^1.0.1:
   dependencies:
     get-stdin "^4.0.1"
 
-strip-json-comments@^3.0.1:
+strip-json-comments@^3.0.1, strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
@@ -12140,6 +12344,16 @@ ts-pnp@^1.1.6:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
+tsconfig-paths@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"
+  integrity sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.1"
+    minimist "^1.2.0"
+    strip-bom "^3.0.0"
+
 tslib@^1.10.0, tslib@^1.11.1, tslib@^1.8.1, tslib@^1.9.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
@@ -12168,6 +12382,13 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
+
+type-check@^0.4.0, type-check@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
+  integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
+  dependencies:
+    prelude-ls "^1.2.1"
 
 type-check@~0.3.2:
   version "0.3.2"
@@ -12680,7 +12901,7 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2 || 2"
 
-word-wrap@~1.2.3:
+word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1093,7 +1093,7 @@
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/plugin-transform-typescript" "^7.9.0"
 
-"@babel/runtime-corejs3@^7.8.3":
+"@babel/runtime-corejs3@^7.10.2", "@babel/runtime-corejs3@^7.8.3":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz#02c3029743150188edeb66541195f54600278419"
   integrity sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==
@@ -1108,7 +1108,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
   integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
@@ -2332,6 +2332,14 @@ aria-query@^3.0.0:
     ast-types-flow "0.0.7"
     commander "^2.11.0"
 
+aria-query@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
+  integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+    "@babel/runtime-corejs3" "^7.10.2"
+
 arity-n@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/arity-n/-/arity-n-1.0.4.tgz#d9e76b11733e08569c0847ae7b39b2860b30b745"
@@ -2405,6 +2413,15 @@ array.prototype.flat@^1.2.1, array.prototype.flat@^1.2.3:
   dependencies:
     define-properties "^1.1.3"
     es-abstract "^1.17.0-next.1"
+
+array.prototype.flatmap@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.2.3.tgz#1c13f84a178566042dd63de4414440db9222e443"
+  integrity sha512-OOEk+lkePcg+ODXIpvuU9PAryCikCJyo7GlDG1upleEpQRx6mzL9puEBkozQ5iAx20KV0l3DbyQwqciJtqe5Pg==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
+    function-bind "^1.1.1"
 
 arrify@^1.0.1:
   version "1.0.1"
@@ -2528,7 +2545,12 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.1.tgz#e1e82e4f3e999e2cfd61b161280d16a111f86428"
   integrity sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==
 
-axobject-query@^2.0.2:
+axe-core@^3.5.4:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.5.tgz#84315073b53fa3c0c51676c588d59da09a192227"
+  integrity sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==
+
+axobject-query@^2.0.2, axobject-query@^2.1.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
   integrity sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==
@@ -4827,7 +4849,7 @@ d@1, d@^1.0.1:
     es5-ext "^0.10.50"
     type "^1.0.1"
 
-damerau-levenshtein@^1.0.4:
+damerau-levenshtein@^1.0.4, damerau-levenshtein@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz#143c1641cb3d85c60c32329e26899adea8701791"
   integrity sha512-JVrozIeElnj3QzfUIt8tB8YMluBJom4Vw9qTPpjGYQ9fYlB3D/rb6OordUxf3xeFB35LKWs0xqcO5U6ySvBtug==
@@ -5231,6 +5253,11 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
+emoji-regex@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.0.0.tgz#48a2309cc8a1d2e9d23bc6a67c39b63032e76ea4"
+  integrity sha512-6p1NII1Vm62wni/VR/cUMauVQoxmLVb9csqQlvLz+hO2gk8U2UYDfXHQSUYIBKmZwAKz867IDqG7B+u0mj+M6w==
+
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
@@ -5409,6 +5436,15 @@ eslint-config-airbnb-base@^14.2.0:
     object.assign "^4.1.0"
     object.entries "^1.1.2"
 
+eslint-config-airbnb@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-18.2.0.tgz#8a82168713effce8fc08e10896a63f1235499dcd"
+  integrity sha512-Fz4JIUKkrhO0du2cg5opdyPKQXOI2MvF8KUvN2710nJMT6jaRUpRE2swrJftAjVGL7T1otLM5ieo5RqS1v9Udg==
+  dependencies:
+    eslint-config-airbnb-base "^14.2.0"
+    object.assign "^4.1.0"
+    object.entries "^1.1.2"
+
 eslint-config-prettier@^6.11.0:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz#f6d2238c1290d01c859a8b5c1f7d352a0b0da8b1"
@@ -5509,6 +5545,23 @@ eslint-plugin-jsx-a11y@6.2.3:
     has "^1.0.3"
     jsx-ast-utils "^2.2.1"
 
+eslint-plugin-jsx-a11y@^6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.3.1.tgz#99ef7e97f567cc6a5b8dd5ab95a94a67058a2660"
+  integrity sha512-i1S+P+c3HOlBJzMFORRbC58tHa65Kbo8b52/TwCwSKLohwvpfT5rm2GjGWzOHTEuq4xxf2aRlHHTtmExDQOP+g==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+    aria-query "^4.2.2"
+    array-includes "^3.1.1"
+    ast-types-flow "^0.0.7"
+    axe-core "^3.5.4"
+    axobject-query "^2.1.2"
+    damerau-levenshtein "^1.0.6"
+    emoji-regex "^9.0.0"
+    has "^1.0.3"
+    jsx-ast-utils "^2.4.1"
+    language-tags "^1.0.5"
+
 eslint-plugin-prettier@^3.1.4:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz#168ab43154e2ea57db992a2cd097c828171f75c2"
@@ -5543,6 +5596,23 @@ eslint-plugin-react@7.19.0:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.2"
     xregexp "^4.3.0"
+
+eslint-plugin-react@^7.20.6:
+  version "7.20.6"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.20.6.tgz#4d7845311a93c463493ccfa0a19c9c5d0fd69f60"
+  integrity sha512-kidMTE5HAEBSLu23CUDvj8dc3LdBU0ri1scwHBZjI41oDv4tjsWZKU7MQccFzH1QYPYhsnTF2ovh7JlcIcmxgg==
+  dependencies:
+    array-includes "^3.1.1"
+    array.prototype.flatmap "^1.2.3"
+    doctrine "^2.1.0"
+    has "^1.0.3"
+    jsx-ast-utils "^2.4.1"
+    object.entries "^1.1.2"
+    object.fromentries "^2.0.2"
+    object.values "^1.1.1"
+    prop-types "^15.7.2"
+    resolve "^1.17.0"
+    string.prototype.matchall "^4.0.2"
 
 eslint-scope@^4.0.3:
   version "4.0.3"
@@ -8031,7 +8101,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-jsx-ast-utils@^2.2.1, jsx-ast-utils@^2.2.3:
+jsx-ast-utils@^2.2.1, jsx-ast-utils@^2.2.3, jsx-ast-utils@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz#1114a4c1209481db06c690c2b4f488cc665f657e"
   integrity sha512-z1xSldJ6imESSzOjd3NNkieVJKRlKYSOtMG8SFyCj2FIrvSaSuli/WjpBkEzCBoR9bYYYFgqJw61Xhu7Lcgk+w==
@@ -8096,6 +8166,18 @@ kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
+
+language-subtag-registry@~0.3.2:
+  version "0.3.20"
+  resolved "https://registry.yarnpkg.com/language-subtag-registry/-/language-subtag-registry-0.3.20.tgz#a00a37121894f224f763268e431c55556b0c0755"
+  integrity sha512-KPMwROklF4tEx283Xw0pNKtfTj1gZ4UByp4EsIFWLgBavJltF4TiYPc39k06zSTsLzxTVXXDSpbwaQXaFB4Qeg==
+
+language-tags@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/language-tags/-/language-tags-1.0.5.tgz#d321dbc4da30ba8bf3024e040fa5c14661f9193a"
+  integrity sha1-0yHbxNowuovzAk4ED6XBRmH5GTo=
+  dependencies:
+    language-subtag-registry "~0.3.2"
 
 last-call-webpack-plugin@^3.0.0:
   version "3.0.0"
@@ -10234,7 +10316,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.1.2:
+prettier@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
   integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1166,22 +1166,6 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
-"@eslint/eslintrc@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.1.3.tgz#7d1a2b2358552cc04834c0979bd4275362e37085"
-  integrity sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==
-  dependencies:
-    ajv "^6.12.4"
-    debug "^4.1.1"
-    espree "^7.3.0"
-    globals "^12.1.0"
-    ignore "^4.0.6"
-    import-fresh "^3.2.1"
-    js-yaml "^3.13.1"
-    lodash "^4.17.19"
-    minimatch "^3.0.4"
-    strip-json-comments "^3.1.1"
-
 "@firebase/analytics-types@0.3.1":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@firebase/analytics-types/-/analytics-types-0.3.1.tgz#3c5f5d71129c88295e17e914e34b391ffda1723c"
@@ -2176,7 +2160,7 @@ acorn@^6.0.1, acorn@^6.0.4, acorn@^6.2.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
   integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
 
-acorn@^7.1.1, acorn@^7.4.0:
+acorn@^7.1.1:
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.0.tgz#e1ad486e6c54501634c6c397c5c121daa383607c"
   integrity sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==
@@ -2232,16 +2216,6 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.12.3:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^6.12.4:
-  version "6.12.5"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.5.tgz#19b0e8bae8f476e5ba666300387775fb1a00a4da"
-  integrity sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
-
 alphanum-sort@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
@@ -2256,11 +2230,6 @@ ansi-colors@^3.0.0:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
   integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
-
-ansi-colors@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
-  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
 
 ansi-escapes@^3.0.0:
   version "3.2.0"
@@ -3827,7 +3796,7 @@ chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
@@ -4337,7 +4306,7 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.1, cross-spawn@^7.0.2:
+cross-spawn@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -4927,7 +4896,7 @@ deep-equal@^1.0.1:
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
 
-deep-is@^0.1.3, deep-is@~0.1.3:
+deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
@@ -5300,13 +5269,6 @@ enhanced-resolve@^4.1.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
-enquirer@^2.3.5:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
-  integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
-  dependencies:
-    ansi-colors "^4.1.1"
-
 entities@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
@@ -5598,14 +5560,6 @@ eslint-scope@^5.0.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-scope@^5.1.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
-  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
-  dependencies:
-    esrecurse "^4.3.0"
-    estraverse "^4.1.1"
-
 eslint-utils@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
@@ -5613,14 +5567,14 @@ eslint-utils@^1.4.3:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-utils@^2.0.0, eslint-utils@^2.1.0:
+eslint-utils@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
   integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
+eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
@@ -5668,49 +5622,6 @@ eslint@^6.6.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-eslint@^7.9.0:
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.9.0.tgz#522aeccc5c3a19017cf0cb46ebfd660a79acf337"
-  integrity sha512-V6QyhX21+uXp4T+3nrNfI3hQNBDa/P8ga7LoQOenwrlEFXrEnUEE+ok1dMtaS3b6rmLXhT1TkTIsG75HMLbknA==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@eslint/eslintrc" "^0.1.3"
-    ajv "^6.10.0"
-    chalk "^4.0.0"
-    cross-spawn "^7.0.2"
-    debug "^4.0.1"
-    doctrine "^3.0.0"
-    enquirer "^2.3.5"
-    eslint-scope "^5.1.0"
-    eslint-utils "^2.1.0"
-    eslint-visitor-keys "^1.3.0"
-    espree "^7.3.0"
-    esquery "^1.2.0"
-    esutils "^2.0.2"
-    file-entry-cache "^5.0.1"
-    functional-red-black-tree "^1.0.1"
-    glob-parent "^5.0.0"
-    globals "^12.1.0"
-    ignore "^4.0.6"
-    import-fresh "^3.0.0"
-    imurmurhash "^0.1.4"
-    is-glob "^4.0.0"
-    js-yaml "^3.13.1"
-    json-stable-stringify-without-jsonify "^1.0.1"
-    levn "^0.4.1"
-    lodash "^4.17.19"
-    minimatch "^3.0.4"
-    natural-compare "^1.4.0"
-    optionator "^0.9.1"
-    progress "^2.0.0"
-    regexpp "^3.1.0"
-    semver "^7.2.1"
-    strip-ansi "^6.0.0"
-    strip-json-comments "^3.1.0"
-    table "^5.2.3"
-    text-table "^0.2.0"
-    v8-compile-cache "^2.0.3"
-
 espree@^6.1.2:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-6.2.1.tgz#77fc72e1fd744a2052c20f38a5b575832e82734a"
@@ -5720,21 +5631,12 @@ espree@^6.1.2:
     acorn-jsx "^5.2.0"
     eslint-visitor-keys "^1.1.0"
 
-espree@^7.3.0:
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.0.tgz#dc30437cf67947cf576121ebd780f15eeac72348"
-  integrity sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==
-  dependencies:
-    acorn "^7.4.0"
-    acorn-jsx "^5.2.0"
-    eslint-visitor-keys "^1.3.0"
-
 esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.0.1, esquery@^1.2.0:
+esquery@^1.0.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.3.1.tgz#b78b5828aa8e214e29fb74c4d5b752e1c033da57"
   integrity sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==
@@ -5748,19 +5650,12 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "^4.1.0"
 
-esrecurse@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
-  integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
-  dependencies:
-    estraverse "^5.2.0"
-
 estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
-estraverse@^5.1.0, estraverse@^5.2.0:
+estraverse@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
@@ -5976,7 +5871,7 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
+fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
@@ -6979,7 +6874,7 @@ import-fresh@^2.0.0:
     caller-path "^2.0.0"
     resolve-from "^3.0.0"
 
-import-fresh@^3.0.0, import-fresh@^3.1.0, import-fresh@^3.2.1:
+import-fresh@^3.0.0, import-fresh@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
   integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
@@ -8245,14 +8140,6 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-levn@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
-  integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
-  dependencies:
-    prelude-ls "^1.2.1"
-    type-check "~0.4.0"
-
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -9256,18 +9143,6 @@ optionator@^0.8.1, optionator@^0.8.3:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
     word-wrap "~1.2.3"
-
-optionator@^0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
-  integrity sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==
-  dependencies:
-    deep-is "^0.1.3"
-    fast-levenshtein "^2.0.6"
-    levn "^0.4.1"
-    prelude-ls "^1.2.1"
-    type-check "^0.4.0"
-    word-wrap "^1.2.3"
 
 original@^1.0.0:
   version "1.0.2"
@@ -10342,11 +10217,6 @@ postcss@^7, postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, po
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-prelude-ls@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
-  integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
-
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -10960,7 +10830,7 @@ regexpp@^2.0.1:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
 
-regexpp@^3.0.0, regexpp@^3.1.0:
+regexpp@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
   integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
@@ -11400,7 +11270,7 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@^7.2.1, semver@^7.3.2:
+semver@^7.3.2:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
@@ -12033,7 +11903,7 @@ strip-indent@^1.0.1:
   dependencies:
     get-stdin "^4.0.1"
 
-strip-json-comments@^3.0.1, strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
+strip-json-comments@^3.0.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
@@ -12382,13 +12252,6 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
-
-type-check@^0.4.0, type-check@~0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
-  integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
-  dependencies:
-    prelude-ls "^1.2.1"
 
 type-check@~0.3.2:
   version "0.3.2"
@@ -12901,7 +12764,7 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2 || 2"
 
-word-wrap@^1.2.3, word-wrap@~1.2.3:
+word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==


### PR DESCRIPTION
This adds code formatting and linter rules. The linter and code formatter are not enforced at this time, but can be used manually if anyone wants to use these tools on their branch. 

Work Done:
I am removing refactor. 
Eslint configured in npm/yarn (not enforced)
Pretter configured in npm/yarn (not enforced)
Prettier configured and disabled on VSCode editor settings.
Prettified and eslint out-of-the-box changes for the admin page only. 

Possible next steps:
Olga to add admin page unit tests. 
Add tests and refactor. 
Review and possibly enforce linters and prettier. 


How to Test:
1. Open the PR locally
2. cd client
3. yarn run eslint FILENAME) --fix
4. yarn prettier --write FILENAME
5. Run in VSCod
4. You will see a number of errors in the console (see screenshot below)

