### PR TITLE
Fix scrolling issue in the DEV UI KIT web page

### DIFF
--- a/client-mvp-04/src/utils/uiKit/uiKit.scss
+++ b/client-mvp-04/src/utils/uiKit/uiKit.scss
@@ -35,3 +35,21 @@
     position: static;
   }
 }
+
+@media (max-height: 900px) {
+  .kit-container {
+    height: calc(95vh - 160px);
+  }
+}
+
+@media (max-height: 896px) and (max-width: 420px) {
+  .kit-container {
+    height: calc(100vh - 160px);
+  }
+}
+
+@media (max-width: 374px) {
+  .kit-container {
+    height: calc(100vh - 170px);
+  }
+}


### PR DESCRIPTION
Fixes #489 

🌟️ **Reason**
Our `app-main` class height is changing according to the different screens but `kit-container` class height is staying **628px** across all the screens. Scrolling is happening always for **628px** height, but `app-main` height is becoming less than **628px** for some screens and the scroll bar is going down more than **app-main** height so, the scroll bar is getting disappear and UI stuck at some point.

So, adjusted **kit-container** height for different screens like **app-main** class.
|Current|This PR|
|---------|------|
| ![before](https://j.gifs.com/NOD7Dm.gif)| ![after](https://j.gifs.com/DqNYMY.gif )|