### PR TITLE
fix (user): show user name in footer

### DIFF
--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -170,8 +170,9 @@ UserController.verifySignIn = async function (req, res) {
   }
 };
 
-UserController.verifyMe = function (req, res) {
-  return res.sendStatus(200);
+UserController.verifyMe = async function (req, res) {
+  const user = await User.findById(req.userId);
+  return res.status(200).send(user);
 };
 
 module.exports = UserController;

--- a/client/src/components/Footer.js
+++ b/client/src/components/Footer.js
@@ -22,7 +22,7 @@ const Footer = () => {
 
                 {auth.user ? (
                     <div className="footer-greeting">
-                        <p className="footer-text">{`Hi ${auth.user.email}`}</p>
+                        <p className="footer-text">{`Hi ${auth.user.name.firstName}`}</p>
                         <button className="logout-button" onClick={handleLogout}>{`(LOGOUT)`}</button>
                     </div>
                 ) : (

--- a/client/src/hooks/useProvideAuth.js
+++ b/client/src/hooks/useProvideAuth.js
@@ -14,8 +14,9 @@ export default function useProvideAuth() {
           "x-customrequired-header": headerToSend
         },
       });
-      setUser(response.status === 200);
-      setIsAdmin(response.status === 200);
+      const user = await response.json();
+      setUser(user);
+      setIsAdmin(user.accessLevel === 'admin');
     } catch (err) {
       console.log(err);
     }
@@ -23,7 +24,7 @@ export default function useProvideAuth() {
 
   useEffect(() => {
     checkUser();
-  }, [user, isAdmin]);
+  }, []);
 
   return { user, isAdmin };
 }


### PR DESCRIPTION
This PR fixes one of the problems in #378 

User data is passed down in the response for a request to /api/auth/me. This allows the user name to be accessed in the footer.

Please note that logout functionality is not in this PR.

![image](https://user-images.githubusercontent.com/25188961/116836772-4f4e0000-ab74-11eb-9096-cf4e057bc55a.png)

