### PR TITLE
Checkin bug: meetings not displaying for checking

### DIFF
--- a/backend/workers/closeCheckins.js
+++ b/backend/workers/closeCheckins.js
@@ -71,7 +71,7 @@ module.exports = (cron, fetch) => {
         console.log("Check-ins closed");
     };
 
-    const scheduledTask = cron.schedule('*/10 8-23 * * *', () => {
+    const scheduledTask = cron.schedule('*/30 * * * *', () => {
         runTask();
     });
 

--- a/backend/workers/createRecurringEvents.js
+++ b/backend/workers/createRecurringEvents.js
@@ -161,7 +161,7 @@ module.exports = (cron, fetch) => {
     
     };
 
-    const scheduledTask = cron.schedule('*/10 7-18 * * *', () => {
+    const scheduledTask = cron.schedule('*/30 * * * *', () => {
         runTask();
     });
 

--- a/backend/workers/openCheckins.js
+++ b/backend/workers/openCheckins.js
@@ -72,7 +72,7 @@ module.exports = (cron, fetch) => {
         console.log("Check-ins opened");
     };
 
-    const scheduledTask = cron.schedule('*/10 7-21 * * *', () => {
+    const scheduledTask = cron.schedule('*/30 * * * *', () => {
         runTask();
     });
 


### PR DESCRIPTION
Fixes #522 

I believe that bug was caused by cron jobs that were only running during certain hours of the day (and mysteriously, not the same hours).  If the meeting took place outside of those hours, checkin was not opened. 

Per Alex all of the cron jobs now set to run every thirty minutes. 

Thank you for your support. 