### PR TITLE
Added v0.4 PR Check workflow (closes #650)

### DIFF
--- a/.github/workflows/v0.4-pull-requests.yaml
+++ b/.github/workflows/v0.4-pull-requests.yaml
@@ -1,0 +1,39 @@
+name: PR Checks
+on:
+  push:
+    branches: [development-0.4]
+    paths-ignore:
+      - "*.md"
+  pull_request:
+    branches: [development-0.4]
+    paths-ignore:
+      - "*.md"
+
+jobs:
+  test-backend-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Make envfile
+        uses: SpicyPizza/create-envfile@v1
+        with:
+          envkey_BACKEND_PORT: ${{ secrets.BACKEND_PORT }}
+          envkey_REACT_APP_PROXY: ${{ secrets.REACT_APP_PROXY }}
+          file_name: backend/.env
+      - name: Build the backend container
+        run: docker-compose build backend
+      - name: Run backend unit test suite
+        run: docker-compose run --rm backend yarn run test --testPathIgnorePatterns=routers
+      - name: Run backend code inspection
+        run: docker-compose run --rm backend yarn run lint
+
+  test-client-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build the client container
+        run: docker-compose build client
+      - name: Run client unit test suite
+        run: docker-compose run --rm client yarn run test
+      - name: Run client code inspection
+        run: docker-compose run --rm client yarn run lint

--- a/.github/workflows/v0.4-pull-requests.yaml
+++ b/.github/workflows/v0.4-pull-requests.yaml
@@ -1,0 +1,39 @@
+name: PR Checks
+on:
+  push:
+    branches: [development-0.4]
+    paths-ignore:
+      - "*.md"
+  pull_request:
+    branches: [development-0.4]
+    paths-ignore:
+      - "*.md"
+
+jobs:
+  test-backend-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Make envfile
+        uses: SpicyPizza/create-envfile@v1
+        with:
+          envkey_BACKEND_PORT: ${{ secrets.BACKEND_PORT }}
+          envkey_REACT_APP_PROXY: ${{ secrets.REACT_APP_PROXY }}
+          file_name: backend/.env
+      - name: Build the backend container
+        run: docker-compose build backend
+      - name: Run backend unit test suite
+        run: docker-compose run --rm backend yarn run test --testPathIgnorePatterns=routers
+      - name: Run backend code inspection
+        run: docker-compose run --rm client yarn run lint
+
+  test-client-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build the client container
+        run: docker-compose build client
+      - name: Run client unit test suite
+        run: docker-compose run --rm client yarn run test
+      - name: Run client code inspection
+        run: docker-compose run --rm client yarn run lint

--- a/client/Dockerfile.client
+++ b/client/Dockerfile.client
@@ -1,4 +1,4 @@
-FROM node:14.11.0 AS client-mvp-development
+FROM node:14.11.0 AS client-development
 RUN mkdir /srv/client && chown node:node /srv/client
 WORKDIR /srv/client
 USER node
@@ -6,7 +6,7 @@ RUN mkdir -p node_modules
 COPY --chown=node:node package.json ./
 RUN npm install --silent
 
-FROM node:14.11.0-slim AS client-mvp-builder
+FROM node:14.11.0-slim AS client-builder
 USER node
 WORKDIR /srv/client
 COPY --from=client-mvp-development /srv/client/node_modules node_modules
@@ -14,7 +14,7 @@ COPY . .
 USER root
 RUN npm run build
 
-FROM nginx as client-mvp-production
+FROM nginx as client-production
 EXPOSE 3001
 COPY /nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY --from=client-mvp-builder /srv/client/build /usr/share/nginx/html/


### PR DESCRIPTION
# Notes
Used the existing `all-pull-requests.yaml` file as a template, with the following changes:

- action targets the `development-0.4` branch ONLY
- action triggers on both PR and direct push (not that this should happen in the head repository, but it made testing easier)
- added lint validation to backend and client