### PR TITLE
Allow PMs to edit permitted project fields

### DIFF
--- a/client/src/components/manageProjects/editProject.js
+++ b/client/src/components/manageProjects/editProject.js
@@ -7,8 +7,6 @@ import { REACT_APP_CUSTOM_REQUEST_HEADER } from '../../utils/globalSettings';
 //for user level block access to all except for the ones checked
 
 const EditProject = (props) => {
-  console.log('editProject.js: props:', props);
-
   const headerToSend = REACT_APP_CUSTOM_REQUEST_HEADER;
 
   //const [currentProjectData, setCurrentProjectData] = useState(props.projectToEdit);

--- a/client/src/components/manageProjects/editProject.js
+++ b/client/src/components/manageProjects/editProject.js
@@ -1,207 +1,226 @@
-import React, { useState }  from 'react';
+import React, { useState } from 'react';
 import '../../sass/ManageProjects.scss';
 import EditableField from './editableField';
-import { REACT_APP_CUSTOM_REQUEST_HEADER } from "../../utils/globalSettings";
+import { REACT_APP_CUSTOM_REQUEST_HEADER } from '../../utils/globalSettings';
 
+// Need to hold user state to check which type of user they are and conditionally render editing fields in this component
+//for user level block access to all except for the ones checked
 
-const EditProjectInfo  = ( props ) => {
+const EditProject = (props) => {
+  console.log('editProject.js: props:', props);
 
   const headerToSend = REACT_APP_CUSTOM_REQUEST_HEADER;
 
   //const [currentProjectData, setCurrentProjectData] = useState(props.projectToEdit);
 
   const updateProject = async (projectId, fieldName, fieldValue) => {
-
     // These field are arrays, but the form makes them comma separated strings, so this adds it back to db as an arrray.
-    if (fieldName === 'partners' || fieldName === 'recruitingCategories') {  
+    if (fieldName === 'partners' || fieldName === 'recruitingCategories') {
       if (!Array.isArray(fieldValue)) {
         fieldValue = fieldValue
-        .split(',')
-        .filter(x => x !== "")
-        .map(y => y.trim());
+          .split(',')
+          .filter((x) => x !== '')
+          .map((y) => y.trim());
       }
     }
-    
+
     // Update database
     const url = `/api/projects/${projectId}`;
     const requestOptions = {
-        method: 'PATCH',
-        headers: {
-            "Content-Type": "application/json",
-            "x-customrequired-header": headerToSend
-        },
-        body: JSON.stringify({ [fieldName]: fieldValue })
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-customrequired-header': headerToSend,
+      },
+      body: JSON.stringify({ [fieldName]: fieldValue }),
     };
 
     try {
-        const response = await fetch(url, requestOptions); 
-        const resJson = await response.json();
+      const response = await fetch(url, requestOptions);
+      const resJson = await response.json();
 
-        return resJson;
+      return resJson;
     } catch (error) {
-        console.log(`update user error: `, error);
-        alert("Server not responding.  Please try again.");
+      console.log(`update user error: `, error);
+      alert('Server not responding.  Please try again.');
     }
   };
 
-
   // Add commas to arrays for display
-  const partnerDataFormatted = props.projectToEdit.partners.join(", ");
-  const recrutingDataFormatted = props.projectToEdit.recruitingCategories.join(", ");
-  
+  const partnerDataFormatted = props.projectToEdit.partners.join(', ');
+  const recrutingDataFormatted =
+    props.projectToEdit.recruitingCategories.join(', ');
 
   return (
     <div>
-      <div className="project-list-heading">Project: {props.projectToEdit.name}</div>
+      <div className="project-list-heading">
+        Project: {props.projectToEdit.name}
+      </div>
 
       <div>
-        <EditableField 
-          fieldData={props.projectToEdit.name} 
-          fieldName="name" 
+        <EditableField
+          fieldData={props.projectToEdit.name}
+          fieldName="name"
           updateProject={updateProject}
           renderUpdatedProj={props.renderUpdatedProj}
           projId={props.projectToEdit._id}
           fieldType="text"
           fieldTitle="Name:"
+          // accessLevel={props.userAccessLevel}
         />
       </div>
       <div className="editable-field-div">
-        <EditableField 
-          fieldData={props.projectToEdit.description} 
-          fieldName="description" 
+        <EditableField
+          fieldData={props.projectToEdit.description}
+          fieldName="description"
           updateProject={updateProject}
           renderUpdatedProj={props.renderUpdatedProj}
           projId={props.projectToEdit._id}
           fieldType="textarea"
           fieldTitle="Description:"
+          // accessLevel={props.userAccessLevel}
         />
       </div>
       <div className="editable-field-div">
-        <EditableField 
-          fieldData={props.projectToEdit.location} 
-          fieldName="location" 
+        <EditableField
+          fieldData={props.projectToEdit.location}
+          fieldName="location"
           updateProject={updateProject}
           renderUpdatedProj={props.renderUpdatedProj}
           projId={props.projectToEdit._id}
           fieldType="text"
           fieldTitle="Location:"
+          // accessLevel={props.userAccessLevel}
         />
       </div>
       <div className="editable-field-div">
-        <EditableField 
-          fieldData={props.projectToEdit.githubIdentifier} 
-          fieldName="githubIdentifier" 
+        <EditableField
+          fieldData={props.projectToEdit.githubIdentifier}
+          fieldName="githubIdentifier"
           updateProject={updateProject}
           renderUpdatedProj={props.renderUpdatedProj}
           projId={props.projectToEdit._id}
           fieldType="text"
           fieldTitle="GitHub Identifier:"
+          // accessLevel={props.userAccessLevel}
         />
-      </div> 
+      </div>
       <div className="editable-field-div">
-        <EditableField 
-          fieldData={props.projectToEdit.githubUrl} 
-          fieldName="githubUrl" 
+        <EditableField
+          fieldData={props.projectToEdit.githubUrl}
+          fieldName="githubUrl"
           updateProject={updateProject}
           renderUpdatedProj={props.renderUpdatedProj}
           projId={props.projectToEdit._id}
           fieldType="text"
           fieldTitle="GitHib URL:"
+          // accessLevel={props.userAccessLevel}
         />
       </div>
       <div className="editable-field-div">
-        <EditableField 
-          fieldData={props.projectToEdit.slackUrl} 
-          fieldName="slackUrl" 
+        <EditableField
+          fieldData={props.projectToEdit.slackUrl}
+          fieldName="slackUrl"
           updateProject={updateProject}
           renderUpdatedProj={props.renderUpdatedProj}
           projId={props.projectToEdit._id}
           fieldType="text"
           fieldTitle="Slack URL:"
+          // accessLevel={props.userAccessLevel}
         />
       </div>
       <div className="editable-field-div">
-        <EditableField 
-          fieldData={props.projectToEdit.googleDriveUrl} 
-          fieldName="googleDriveUrl" 
+        <EditableField
+          fieldData={props.projectToEdit.googleDriveUrl}
+          fieldName="googleDriveUrl"
           updateProject={updateProject}
           renderUpdatedProj={props.renderUpdatedProj}
           projId={props.projectToEdit._id}
           fieldType="text"
           fieldTitle="Google Drive URL:"
+          accessLevel={props.userAccessLevel}
         />
       </div>
       <div className="editable-field-div">
-        <EditableField 
-          fieldData={props.projectToEdit.googleDriveId} 
-          fieldName="googleDriveId" 
+        <EditableField
+          fieldData={props.projectToEdit.googleDriveId}
+          fieldName="googleDriveId"
           updateProject={updateProject}
           renderUpdatedProj={props.renderUpdatedProj}
           projId={props.projectToEdit._id}
           fieldType="text"
           fieldTitle="Google Drive ID:"
+          // accessLevel={props.userAccessLevel}
         />
       </div>
       <div className="editable-field-div">
-        <EditableField 
-          fieldData={props.projectToEdit.hflaWebsiteUrl} 
-          fieldName="hflaWebsiteUrl" 
+        <EditableField
+          fieldData={props.projectToEdit.hflaWebsiteUrl}
+          fieldName="hflaWebsiteUrl"
           updateProject={updateProject}
           renderUpdatedProj={props.renderUpdatedProj}
           projId={props.projectToEdit._id}
           fieldType="text"
           fieldTitle="HfLA Website URL:"
+          // accessLevel={props.userAccessLevel}
         />
       </div>
       <div className="editable-field-div">
-        <EditableField 
-          fieldData={props.projectToEdit.videoConferenceLink} 
-          fieldName="videoConferenceLink" 
+        <EditableField
+          fieldData={props.projectToEdit.videoConferenceLink}
+          fieldName="videoConferenceLink"
           updateProject={updateProject}
           renderUpdatedProj={props.renderUpdatedProj}
           projId={props.projectToEdit._id}
           fieldType="text"
           fieldTitle="Video Conference Link:"
+          accessLevel={props.userAccessLevel}
         />
       </div>
       <div className="editable-field-div">
-        <EditableField 
-          fieldData={props.projectToEdit.lookingDescription} 
-          fieldName="lookingDescription" 
+        <EditableField
+          fieldData={props.projectToEdit.lookingDescription}
+          fieldName="lookingDescription"
           updateProject={updateProject}
           renderUpdatedProj={props.renderUpdatedProj}
           projId={props.projectToEdit._id}
           fieldType="text"
           fieldTitle="Looking For Description:"
+          // accessLevel={props.userAccessLevel}
         />
       </div>
       <div className="editable-field-div">
-        <EditableField 
-          fieldData={partnerDataFormatted} 
-          fieldName="partners" 
+        <EditableField
+          fieldData={partnerDataFormatted}
+          fieldName="partners"
           updateProject={updateProject}
           renderUpdatedProj={props.renderUpdatedProj}
           projId={props.projectToEdit._id}
           fieldType="text"
           fieldTitle="Partners (comma separated):"
+          accessLevel={props.userAccessLevel}
         />
-      </div> 
+      </div>
       <div className="editable-field-div">
-        <EditableField 
-          fieldData={recrutingDataFormatted} 
-          fieldName="recruitingCategories" 
+        <EditableField
+          fieldData={recrutingDataFormatted}
+          fieldName="recruitingCategories"
           updateProject={updateProject}
           renderUpdatedProj={props.renderUpdatedProj}
           projId={props.projectToEdit._id}
           fieldType="text"
           fieldTitle="Recruiting Categories (comma separated):"
+          // accessLevel={props.userAccessLevel}
         />
-      </div> 
-      
-      
-      <div><button className="button-back" onClick={props.goSelectProject}>Back to Select Project</button></div>
+      </div>
+
+      <div>
+        <button className="button-back" onClick={props.goSelectProject}>
+          Back to Select Project
+        </button>
+      </div>
     </div>
   );
 };
 
-export default EditProjectInfo;
+export default EditProject;

--- a/client/src/components/manageProjects/editProject.js
+++ b/client/src/components/manageProjects/editProject.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import '../../sass/ManageProjects.scss';
 import EditableField from './editableField';
 import { REACT_APP_CUSTOM_REQUEST_HEADER } from '../../utils/globalSettings';

--- a/client/src/components/manageProjects/editProject.js
+++ b/client/src/components/manageProjects/editProject.js
@@ -66,7 +66,8 @@ const EditProject = (props) => {
           projId={props.projectToEdit._id}
           fieldType="text"
           fieldTitle="Name:"
-          // accessLevel={props.userAccessLevel}
+          accessLevel={props.userAccessLevel}
+          canEdit={['admin']}
         />
       </div>
       <div className="editable-field-div">
@@ -78,7 +79,8 @@ const EditProject = (props) => {
           projId={props.projectToEdit._id}
           fieldType="textarea"
           fieldTitle="Description:"
-          // accessLevel={props.userAccessLevel}
+          accessLevel={props.userAccessLevel}
+          canEdit={['admin']}
         />
       </div>
       <div className="editable-field-div">
@@ -90,7 +92,8 @@ const EditProject = (props) => {
           projId={props.projectToEdit._id}
           fieldType="text"
           fieldTitle="Location:"
-          // accessLevel={props.userAccessLevel}
+          accessLevel={props.userAccessLevel}
+          canEdit={['admin']}
         />
       </div>
       <div className="editable-field-div">
@@ -102,7 +105,8 @@ const EditProject = (props) => {
           projId={props.projectToEdit._id}
           fieldType="text"
           fieldTitle="GitHub Identifier:"
-          // accessLevel={props.userAccessLevel}
+          accessLevel={props.userAccessLevel}
+          canEdit={['admin']}
         />
       </div>
       <div className="editable-field-div">
@@ -114,7 +118,8 @@ const EditProject = (props) => {
           projId={props.projectToEdit._id}
           fieldType="text"
           fieldTitle="GitHib URL:"
-          // accessLevel={props.userAccessLevel}
+          accessLevel={props.userAccessLevel}
+          canEdit={['admin']}
         />
       </div>
       <div className="editable-field-div">
@@ -126,7 +131,8 @@ const EditProject = (props) => {
           projId={props.projectToEdit._id}
           fieldType="text"
           fieldTitle="Slack URL:"
-          // accessLevel={props.userAccessLevel}
+          accessLevel={props.userAccessLevel}
+          canEdit={['admin']}
         />
       </div>
       <div className="editable-field-div">
@@ -139,6 +145,7 @@ const EditProject = (props) => {
           fieldType="text"
           fieldTitle="Google Drive URL:"
           accessLevel={props.userAccessLevel}
+          canEdit={['admin', 'user']}
         />
       </div>
       <div className="editable-field-div">
@@ -150,7 +157,8 @@ const EditProject = (props) => {
           projId={props.projectToEdit._id}
           fieldType="text"
           fieldTitle="Google Drive ID:"
-          // accessLevel={props.userAccessLevel}
+          accessLevel={props.userAccessLevel}
+          canEdit={['admin']}
         />
       </div>
       <div className="editable-field-div">
@@ -162,7 +170,8 @@ const EditProject = (props) => {
           projId={props.projectToEdit._id}
           fieldType="text"
           fieldTitle="HfLA Website URL:"
-          // accessLevel={props.userAccessLevel}
+          accessLevel={props.userAccessLevel}
+          canEdit={['admin']}
         />
       </div>
       <div className="editable-field-div">
@@ -175,6 +184,7 @@ const EditProject = (props) => {
           fieldType="text"
           fieldTitle="Video Conference Link:"
           accessLevel={props.userAccessLevel}
+          canEdit={['admin', 'user']}
         />
       </div>
       <div className="editable-field-div">
@@ -186,7 +196,8 @@ const EditProject = (props) => {
           projId={props.projectToEdit._id}
           fieldType="text"
           fieldTitle="Looking For Description:"
-          // accessLevel={props.userAccessLevel}
+          accessLevel={props.userAccessLevel}
+          canEdit={['admin']}
         />
       </div>
       <div className="editable-field-div">
@@ -199,6 +210,7 @@ const EditProject = (props) => {
           fieldType="text"
           fieldTitle="Partners (comma separated):"
           accessLevel={props.userAccessLevel}
+          canEdit={['admin', 'user']}
         />
       </div>
       <div className="editable-field-div">
@@ -210,7 +222,8 @@ const EditProject = (props) => {
           projId={props.projectToEdit._id}
           fieldType="text"
           fieldTitle="Recruiting Categories (comma separated):"
-          // accessLevel={props.userAccessLevel}
+          accessLevel={props.userAccessLevel}
+          canEdit={['admin']}
         />
       </div>
 

--- a/client/src/components/manageProjects/editableField.js
+++ b/client/src/components/manageProjects/editableField.js
@@ -1,72 +1,126 @@
 import React, { useState, useRef, useEffect } from 'react';
 import '../../sass/ManageProjects.scss';
 
-
-
-const EditableField  = (
-    { projId, fieldData, fieldName, updateProject, renderUpdatedProj, fieldType, fieldTitle }
-) => {
+const EditableField = ({
+  projId,
+  fieldData,
+  fieldName,
+  updateProject,
+  renderUpdatedProj,
+  fieldType,
+  fieldTitle,
+  accessLevel,
+}) => {
   const [fieldValue, setFieldValue] = useState(fieldData);
   const [editable, setEditable] = useState(false);
-  const ref = useRef(); 
+  const [userAccessLevel] = useState(accessLevel);
+  const [userCanEdit, setUserCanEdit] = useState(false);
+  const ref = useRef();
+
+  console.log('editableField: props: editable:', editable);
+  console.log('editableFields: props: accessLevel: ', userAccessLevel);
+  console.log('editableFields: props: accessLevel: ', accessLevel);
+  console.log('usercanedit', userCanEdit);
+
+  // create function that checks the user has access to edit all fields
+
+  const canEdit = () => {
+    // get user accessLevel
+    console.log(
+      `editableField: canEdit: activated onClick: editable?: ${editable} : and accessLevel: ${accessLevel}`
+    );
+
+    if (userAccessLevel === 'user') {
+      setUserCanEdit(true);
+    }
+  };
 
   // Update the displayed results to match the change just made to the db
-  useEffect(() => {      
+  useEffect(() => {
+    canEdit();
     if (editable) {
       ref.current.focus();
       setFieldValue(fieldData);
-    } 
-  },[editable]);
+    }
+  }, [editable, userCanEdit]);
 
   return (
+    // here goes the conditional rendering
+    // this button will be disabled if user !admin
     <div>
-      <div>{fieldTitle}<span className="project-edit-button" onClick={() => setEditable(true)} > [edit]</span></div>
-      {editable ?
-      
-        (fieldType === "textarea") ?
+      <div>
+        {fieldTitle}
+        {userCanEdit === true ? (
+          <span
+            className="project-edit-button"
+            onClick={() => {
+              setEditable(true);
+            }}
+          >
+            {' '}
+            [edit]
+          </span>
+        ) : (
+          <span className="project-edit-button" style={{ color: 'gray' }}>
+            {' '}
+            [only certain users can edit this field]
+          </span>
+        )}
+      </div>
+
+      {editable ? (
+        fieldType === 'textarea' ? (
           <textarea
             ref={ref}
             className="editable-field"
-            onBlur={(e)=>{
-              updateProject(projId, fieldName, fieldValue)
-              .then(proj => {renderUpdatedProj(proj); setEditable(false)})
+            onBlur={(e) => {
+              updateProject(projId, fieldName, fieldValue).then((proj) => {
+                renderUpdatedProj(proj);
+                setEditable(false);
+              });
             }}
-            onChange={e=>{
-              setFieldValue(e.target.value)
+            onChange={(e) => {
+              setFieldValue(e.target.value);
               const input = e.target;
               const onEnterKey = (e) => {
                 if (e.keyCode === 13) {
-                  input.removeEventListener('keydown', onEnterKey)
+                  input.removeEventListener('keydown', onEnterKey);
                   input.blur();
                 }
-              }
-              input.addEventListener('keydown', onEnterKey)
+              };
+              input.addEventListener('keydown', onEnterKey);
             }}
-          >{fieldValue}</textarea>
-        :
-        <input 
-          ref={ref}
-          type="text"
-          className="editable-field"
-          value={fieldValue}
-          onBlur={(e)=>{
-            updateProject(projId, fieldName, fieldValue)
-            .then(proj => {renderUpdatedProj(proj); setEditable(false)})
-          }}
-          onChange={e=>{
-            setFieldValue(e.target.value)
-            const input = e.target;
-            const onEnterKey = (e) => {
-              if (e.keyCode === 13) {
-                input.removeEventListener('keydown', onEnterKey)
-                input.blur();
-              }
-            }
-            input.addEventListener('keydown', onEnterKey)
-          }}
-        />
-      : <div className="section-content">{fieldData}</div>
-      }  
+          >
+            {fieldValue}
+          </textarea>
+        ) : (
+          <input
+            ref={ref}
+            type="text"
+            className="editable-field"
+            value={fieldValue}
+            onBlur={(e) => {
+              updateProject(projId, fieldName, fieldValue).then((proj) => {
+                renderUpdatedProj(proj);
+                setEditable(false);
+              });
+            }}
+            onChange={(e) => {
+              setFieldValue(e.target.value);
+              const input = e.target;
+              const onEnterKey = (e) => {
+                if (e.keyCode === 13) {
+                  input.removeEventListener('keydown', onEnterKey);
+                  input.blur();
+                }
+              };
+              input.addEventListener('keydown', onEnterKey);
+            }}
+          />
+        )
+      ) : (
+        <div className="section-content">{fieldData}</div>
+      )}
     </div>
   );
 };

--- a/client/src/components/manageProjects/editableField.js
+++ b/client/src/components/manageProjects/editableField.js
@@ -10,39 +10,29 @@ const EditableField = ({
   fieldType,
   fieldTitle,
   accessLevel,
+  canEdit,
 }) => {
   const [fieldValue, setFieldValue] = useState(fieldData);
   const [editable, setEditable] = useState(false);
-  const [userAccessLevel] = useState(accessLevel);
-  const [userCanEdit, setUserCanEdit] = useState(false);
+  const [notRestricted, setNotRestricted] = useState(false);
   const ref = useRef();
-
-  console.log('editableField: props: editable:', editable);
-  console.log('editableFields: props: accessLevel: ', userAccessLevel);
   console.log('editableFields: props: accessLevel: ', accessLevel);
-  console.log('usercanedit', userCanEdit);
 
   // create function that checks the user has access to edit all fields
 
-  const canEdit = () => {
-    // get user accessLevel
-    console.log(
-      `editableField: canEdit: activated onClick: editable?: ${editable} : and accessLevel: ${accessLevel}`
-    );
-
-    if (userAccessLevel === 'user') {
-      setUserCanEdit(true);
-    }
+  const checkUser = () => {
+    const permitted = canEdit.includes(accessLevel);
+    setNotRestricted(permitted);
   };
 
   // Update the displayed results to match the change just made to the db
   useEffect(() => {
-    canEdit();
+    checkUser();
     if (editable) {
       ref.current.focus();
       setFieldValue(fieldData);
     }
-  }, [editable, userCanEdit]);
+  }, [editable]);
 
   return (
     // here goes the conditional rendering
@@ -50,7 +40,7 @@ const EditableField = ({
     <div>
       <div>
         {fieldTitle}
-        {userCanEdit === true ? (
+        {notRestricted ? (
           <span
             className="project-edit-button"
             onClick={() => {

--- a/client/src/components/manageProjects/editableField.js
+++ b/client/src/components/manageProjects/editableField.js
@@ -52,7 +52,9 @@ const EditableField = ({
         ) : (
           <span className="project-edit-button" style={{ color: 'gray' }}>
             {' '}
-            [only certain users can edit this field]
+            <a href="https://github.com/chukalicious/VRMS/blob/feature/allow-pm-to-edit-project-fields/team-lead-contact-info.md">
+              [Contact your team lead to make changes to this field]
+            </a>
           </span>
         )}
       </div>

--- a/client/src/components/manageProjects/editableField.js
+++ b/client/src/components/manageProjects/editableField.js
@@ -16,7 +16,6 @@ const EditableField = ({
   const [editable, setEditable] = useState(false);
   const [notRestricted, setNotRestricted] = useState(false);
   const ref = useRef();
-  console.log('editableFields: props: accessLevel: ', accessLevel);
 
   // create function that checks the user has access to edit all fields
 

--- a/client/src/pages/ManageProjects.js
+++ b/client/src/pages/ManageProjects.js
@@ -2,20 +2,23 @@ import React, { useState, useEffect } from 'react';
 import { Redirect } from 'react-router-dom';
 import '../sass/ManageProjects.scss';
 import useAuth from '../hooks/useAuth';
-import { REACT_APP_CUSTOM_REQUEST_HEADER } from "../utils/globalSettings";
+import { REACT_APP_CUSTOM_REQUEST_HEADER } from '../utils/globalSettings';
 import SelectProject from '../components/manageProjects/selectProject.js';
-import EditProjectInfo from '../components/manageProjects/editProject.js';
+import EditProject from '../components/manageProjects/editProject.js';
 
 const ManageProjects = () => {
-
   const headerToSend = REACT_APP_CUSTOM_REQUEST_HEADER;
 
   const [auth] = useAuth();
+  console.log('ManageProjects: auth', auth.isAdmin);
   const [projects, setProjects] = useState([]);
   const [projectToEdit, setProjectToEdit] = useState([]);
   const [recurringEvents, setRecurringEvents] = useState([]);
-  const [componentToDisplay, setComponentToDisplay] = useState (''); // displayProjectInfo, editMeetingTime or editProjectInfor 
+  const [componentToDisplay, setComponentToDisplay] = useState(''); // displayProjectInfo, editMeetingTime or editProjectInfor
+  const [accessLevel, setAccessLevel] = useState();
   const user = auth?.user;
+
+  console.log('ManageProjects: user: accessLevel: ', user.accessLevel);
 
   // Fetch projects from db
   async function fetchProjects() {
@@ -33,21 +36,21 @@ const ManageProjects = () => {
     }
   }
 
-    // Fetch recurringEvents
-    async function fetchRecurringEvents() {
-      try {
-        const res = await fetch('/api/recurringEvents/', {
-          headers: {
-            'x-customrequired-header': headerToSend,
-          },
-        });
-        const resJson = await res.json();
-        setRecurringEvents(resJson);
-      } catch (error) {
-        console.log(`fetchProjects error: ${error}`);
-        alert('Server not responding.  Please refresh the page.');
-      }
+  // Fetch recurringEvents
+  async function fetchRecurringEvents() {
+    try {
+      const res = await fetch('/api/recurringEvents/', {
+        headers: {
+          'x-customrequired-header': headerToSend,
+        },
+      });
+      const resJson = await res.json();
+      setRecurringEvents(resJson);
+    } catch (error) {
+      console.log(`fetchProjects error: ${error}`);
+      alert('Server not responding.  Please refresh the page.');
     }
+  }
 
   useEffect(() => {
     fetchProjects();
@@ -70,15 +73,14 @@ const ManageProjects = () => {
     return <Redirect to="/" />;
   }
 
-  const projectSelectClickHandler = project => event => {
+  const projectSelectClickHandler = (project) => (event) => {
     setProjectToEdit(project);
     setComponentToDisplay('editProjectInfo');
   };
 
   const goSelectProject = () => {
     setComponentToDisplay('selectProject');
-}
-
+  };
 
   switch (componentToDisplay) {
     case 'editMeetingTime':
@@ -86,21 +88,22 @@ const ManageProjects = () => {
       break;
     case 'editProjectInfo':
       return (
-        <EditProjectInfo
+        <EditProject
           projectToEdit={projectToEdit}
           goSelectProject={goSelectProject}
           recurringEvents={recurringEvents}
           renderUpdatedProj={renderUpdatedProj}
+          userAccessLevel={user.accessLevel}
         />
       );
       break;
     default:
       return (
-        <SelectProject 
-          projectSelectClickHandler = {projectSelectClickHandler}
-          accessLevel = {user?.accessLevel}
-          projects = {projects}
-          user = {user}
+        <SelectProject
+          projectSelectClickHandler={projectSelectClickHandler}
+          accessLevel={user?.accessLevel}
+          projects={projects}
+          user={user}
         />
       );
   }

--- a/client/src/pages/ManageProjects.js
+++ b/client/src/pages/ManageProjects.js
@@ -14,7 +14,6 @@ const ManageProjects = () => {
   const [projectToEdit, setProjectToEdit] = useState([]);
   const [recurringEvents, setRecurringEvents] = useState([]);
   const [componentToDisplay, setComponentToDisplay] = useState(''); // displayProjectInfo, editMeetingTime or editProjectInfor
-  const [accessLevel, setAccessLevel] = useState();
   const user = auth?.user;
 
   // Fetch projects from db

--- a/client/src/pages/ManageProjects.js
+++ b/client/src/pages/ManageProjects.js
@@ -10,15 +10,12 @@ const ManageProjects = () => {
   const headerToSend = REACT_APP_CUSTOM_REQUEST_HEADER;
 
   const [auth] = useAuth();
-  console.log('ManageProjects: auth', auth.isAdmin);
   const [projects, setProjects] = useState([]);
   const [projectToEdit, setProjectToEdit] = useState([]);
   const [recurringEvents, setRecurringEvents] = useState([]);
   const [componentToDisplay, setComponentToDisplay] = useState(''); // displayProjectInfo, editMeetingTime or editProjectInfor
   const [accessLevel, setAccessLevel] = useState();
   const user = auth?.user;
-
-  console.log('ManageProjects: user: accessLevel: ', user.accessLevel);
 
   // Fetch projects from db
   async function fetchProjects() {

--- a/team-lead-contact-info.md
+++ b/team-lead-contact-info.md
@@ -1,0 +1,1 @@
+## Team Lead Contact Sheet

--- a/team-lead-contact-info.md
+++ b/team-lead-contact-info.md
@@ -1,1 +1,11 @@
 ## Team Lead Contact Sheet
+
+# Please find your team lead's email from the table below to request the desired changes.
+
+| Team Lead | Email |
+| :-------: | :---: |
+|           |       |
+|           |       |
+|           |       |
+|           |       |
+|           |       |

--- a/team-lead-contact-info.md
+++ b/team-lead-contact-info.md
@@ -1,6 +1,6 @@
 ## Team Lead Contact Sheet
 
-# Please find your team lead's email from the table below to request the desired changes.
+### Please find your team lead's email from the table below to request the desired changes.
 
 | Team Lead | Email |
 | :-------: | :---: |


### PR DESCRIPTION
Closes #701

### Description:

This PR restricts the updating of specific fields in the project object, granting full access to editable fields to users with 'admin' access level, and restricted access to users with 'user' access level. 

### Action taken:

- Created a canEdit prop for the field components that's an array of types of users allowed to make changes to the field
- Compared the logged in user's access level to the values in the canEdit prop
- If the access level can be found in the array the edit button will be enabled, if not, a link that navigates to a readme doc with instructions will be rendered