### PR TITLE
refactor: create and edit event

### DIFF
--- a/client/src/api/RecurringEventsApiService.js
+++ b/client/src/api/RecurringEventsApiService.js
@@ -6,12 +6,12 @@ class RecurringEventsApiService {
       'Content-Type': 'application/json',
       'x-customrequired-header': REACT_APP_CUSTOM_REQUEST_HEADER,
     };
-    this.baseUserUrl = '/api/recurringEvents/';
+    this.baseUrl = '/api/recurringEvents/';
   }
 
   async fetchRecurringEvents() {
     try {
-      const res = await fetch(this.baseUserUrl, {
+      const res = await fetch(this.baseUrl, {
         headers: this.headers,
       });
       return await res.json();
@@ -19,6 +19,52 @@ class RecurringEventsApiService {
       console.log(`fetchRecurringEvents error: ${error}`);
       alert('Server not responding.  Please refresh the page.');
       return [];
+    }
+  }
+
+  async createNewRecurringEvent(eventToCreate) {
+    const requestOptions = {
+      method: 'POST',
+      headers: this.headers,
+      body: JSON.stringify(eventToCreate),
+    };
+
+    try {
+      return await fetch(this.baseUrl, requestOptions);
+    } catch (error) {
+      console.error(`Add recurring event error: `, error);
+      alert('Server not responding.  Please try again.');
+      return undefined;
+    }
+  }
+
+  async deleteRecurringEvent(recurringEventID) {
+    const requestOptions = {
+      method: 'DELETE',
+      headers: this.headers,
+    };
+
+    try {
+      return await fetch(`${this.baseUrl}/${recurringEventID}`, requestOptions);
+    } catch (error) {
+      console.error(`Delete recurring event error: `, error);
+      alert('Server not responding.  Please try again.');
+      return undefined;
+    }
+  }
+
+  async updateRecurringEvent(eventToUpdate, recurringEventID) {
+    const requestOptions = {
+      method: 'PATCH',
+      headers: this.headers,
+      body: JSON.stringify(eventToUpdate),
+    };
+    try {
+      return await fetch(`${this.baseUrl}/${recurringEventID}`, requestOptions);
+    } catch (error) {
+      console.error(`Update recurring event error: `, error);
+      alert('Server not responding.  Please try again.');
+      return undefined;
     }
   }
 }

--- a/client/src/components/manageProjects/createNewEvent.js
+++ b/client/src/components/manageProjects/createNewEvent.js
@@ -1,18 +1,21 @@
 import React, { useState } from 'react';
 import '../../sass/ManageProjects.scss';
-import { createClockHours } from '../../utils/createClockHours';
-import { REACT_APP_CUSTOM_REQUEST_HEADER } from '../../utils/globalSettings';
 import { findNextOccuranceOfDay } from './utilities/findNextDayOccuranceOfDay';
 import { addDurationToTime } from './utilities/addDurationToTime';
 import { timeConvertFromForm } from './utilities/timeConvertFromForm';
+import EventForm from './eventForm';
 
-const CreateNewEvent = ({ projectName, projectID, newEventReRender }) => {
-  const headerToSend = REACT_APP_CUSTOM_REQUEST_HEADER;
-
+const CreateNewEvent = ({
+  projectName,
+  projectID,
+  createNewRecurringEvent,
+}) => {
   // These are the initial form values
   const initialFormValues = {
     name: `${projectName} Team Meeting`,
     eventType: 'Team Meeting',
+    description: '',
+    videoConferenceLink: '',
     day: '0',
     startTime: '7:00pm',
     duration: '1',
@@ -38,30 +41,7 @@ const CreateNewEvent = ({ projectName, projectID, newEventReRender }) => {
     setFormValues({ ...formValues, [event.target.name]: event.target.value });
   };
 
-  // TODO: Pull out to recurring events api service
-  // *** Create New Recurring Event functions ***
-  const createNewRecurringEvent = async (eventToCreate) => {
-    const url = `/api/recurringEvents/`;
-    const requestOptions = {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-customrequired-header': headerToSend,
-      },
-      body: JSON.stringify(eventToCreate),
-    };
-
-    const response = await fetch(url, requestOptions);
-    if (!response.ok) {
-      throw new Error(`HTTP error!  ${response.status}`);
-    }
-    const data = await response.json();
-    return data;
-  };
-
   const handleEventCreate = () => {
-    /* ToDo: Ask Bonnie what, if any, validation is required */
-
     const date = findNextOccuranceOfDay(formValues.day);
     const startTimeDate = timeConvertFromForm(date, formValues.startTime);
     const endTime = addDurationToTime(startTimeDate, formValues.duration);
@@ -97,14 +77,7 @@ const CreateNewEvent = ({ projectName, projectID, newEventReRender }) => {
       videoConferenceLink: formValues.videoConferenceLink,
     };
 
-    createNewRecurringEvent(theNewEvent)
-      .then((data) => {
-        newEventReRender(data);
-      })
-      .catch((error) => {
-        console.log(`Create Recurring Event Error: `, error);
-        alert('Server not responding.  Please try again.');
-      });
+    createNewRecurringEvent(theNewEvent);
   };
 
   // Handle submission of new recurring event form
@@ -114,115 +87,13 @@ const CreateNewEvent = ({ projectName, projectID, newEventReRender }) => {
     setDisplayForm(false);
   };
 
-  // This creates the clock hours for the form
-  const clockHours = createClockHours();
-
-  // TODO: reusable event form component
   if (displayForm) {
     return (
-      <div className="event-form-box">
-        <h3 className="event-form-title">Create New Recurring Event</h3>
-        <label className="event-form-label" htmlFor="name">
-          Meeting Name:
-          <input
-            id="name"
-            placeholder="Meeting name..."
-            name="name"
-            value={formValues.name}
-            onChange={handleInputChange}
-          />
-        </label>
-
-        <label className="event-form-label" htmlFor="eventType">
-          Event Type:
-          <select
-            id="eventType"
-            value={formValues.eventType}
-            onChange={handleInputChange}
-            name="eventType"
-          >
-            <option value="Team Meeting">Team Meeting</option>
-            <option value="Onboarding">Onboarding</option>
-          </select>
-        </label>
-
-        <label className="event-form-label" htmlFor="description">
-          Description:
-          <input
-            id="description"
-            placeholder="Meeting description..."
-            name="description"
-            value={formValues.description}
-            onChange={handleInputChange}
-          />
-        </label>
-
-        <label className="event-form-label" htmlFor="videoConferenceLink">
-          Videoconference Link:
-          <input
-            id="videoConferenceLink"
-            placeholder="Videoconference Link..."
-            name="videoConferenceLink"
-            value={formValues.videoConferenceLink}
-            onChange={handleInputChange}
-          />
-        </label>
-
-        <label className="event-form-label" htmlFor="day">
-          Day of the Week:
-          <select
-            id="day"
-            value={formValues.day}
-            onChange={handleInputChange}
-            name="day"
-          >
-            <option value="0">Sunday</option>
-            <option value="1">Monday</option>
-            <option value="2">Tuesday</option>
-            <option value="3">Wednesday</option>
-            <option value="4">Thursday</option>
-            <option value="5">Friday</option>
-            <option value="6">Saturday</option>
-          </select>
-        </label>
-
-        <label className="event-form-label" htmlFor="startTime">
-          Start Time:
-          <select
-            id="startTime"
-            value={formValues.startTime}
-            onChange={handleInputChange}
-            name="startTime"
-          >
-            {clockHours.map((value) => {
-              return (
-                <option key={value} value={value}>
-                  {value}
-                </option>
-              );
-            })}
-          </select>
-        </label>
-
-        <label className="event-form-label" htmlFor="duration">
-          Duration:
-          <select
-            id="duration"
-            value={formValues.duration}
-            onChange={handleInputChange}
-            name="duration"
-          >
-            <option value=".5">.5</option>
-            <option value="1">1</option>
-            <option value="1.5">1.5</option>
-            <option value="2">2</option>
-            <option value="2.5">2.5</option>
-            <option value="3">3</option>
-            <option value="3.5">3.5</option>
-            <option value="4">4</option>
-          </select>
-        </label>
-
+      <EventForm
+        handleInputChange={handleInputChange}
+        formValues={formValues}
+        title="Create New Recurring Event"
+      >
         <div className="button-box">
           <button
             type="button"
@@ -243,7 +114,7 @@ const CreateNewEvent = ({ projectName, projectID, newEventReRender }) => {
             Cancel
           </button>
         </div>
-      </div>
+      </EventForm>
     );
   }
   return (

--- a/client/src/components/manageProjects/editMeetingTimes.js
+++ b/client/src/components/manageProjects/editMeetingTimes.js
@@ -1,138 +1,95 @@
-import React, { useState, useEffect }  from 'react';
+import React, { useState, useEffect } from 'react';
 import '../../sass/ManageProjects.scss';
 import EditableMeeting from './editableMeeting';
-import { REACT_APP_CUSTOM_REQUEST_HEADER } from "../../utils/globalSettings";
 import CreateNewEvent from './createNewEvent';
 import { readableEvent } from './utilities/readableEvent';
 import { findNextOccuranceOfDay } from './utilities/findNextDayOccuranceOfDay';
 import { addDurationToTime } from './utilities/addDurationToTime';
 import { timeConvertFromForm } from './utilities/timeConvertFromForm';
 
-// This component displays current meeting times for selected project and offers the option to edit those times. 
-const EditMeetingTimes  = ({
-  recurringEvents, 
+// This component displays current meeting times for selected project and offers the option to edit those times.
+const EditMeetingTimes = ({
+  recurringEvents,
   projectToEdit,
   goEditProject,
-  goSelectProject
-  }) => {
-
-  const headerToSend = REACT_APP_CUSTOM_REQUEST_HEADER;
-  const URL = process.env.NODE_ENV === 'prod' ? 'https://www.vrms.io' : 'http://localhost:4000';
-
+  goSelectProject,
+  createNewRecurringEvent,
+  deleteRecurringEvent,
+  updateRecurringEvent,
+}) => {
   const [rEvents, setREvents] = useState([]);
-  const [eventToEdit, setEventToEdit] = useState('');
 
   // Get project recurring events when component loads
   useEffect(() => {
     // Filters the recurring events for this project
-    setREvents(recurringEvents.filter(e => (e?.project?._id === projectToEdit._id)));
-  }, [])
+    setREvents(
+      // eslint-disable-next-line no-underscore-dangle
+      recurringEvents.filter((e) => e?.project?._id === projectToEdit._id)
+    );
+  }, [projectToEdit, recurringEvents, setREvents]);
 
   // Map new array of readable event objects
-  let processedEvents = rEvents.map(function(item) {
-    return readableEvent(item);
-  });
+  const processedEvents = rEvents.map((item) => readableEvent(item));
 
-  /*** Re render functions ***/
-  const deleteEventReRender = (data) => {
-    setREvents(rEvents.filter(e => (e._id !== data._id)));
-  }
-
-  const newEventReRender = (data) => {
-    setREvents([data, ...rEvents]);
-  }
-
-  const updateEventReRender = (data) => {
-    let uEvents = [];
-    
-    for (let i = 0; i < rEvents.length; i++) {
-      if (rEvents[i]._id === data._id) {
-        uEvents.push(data);
-      } else {
-        uEvents.push(rEvents[i]);
-      }
-    }
-    setREvents(uEvents);
-  };
-
-  // update reurringEvent
-  const updateRecurringEvent = async (eventToUpdate, RecurringEventID) => {
-
-    const url = `/api/recurringEvents/${RecurringEventID}`;
-    const requestOptions = {
-        method: 'PATCH',
-        headers: {
-            "Content-Type": "application/json",
-            "x-customrequired-header": headerToSend
-        },
-        body: JSON.stringify(eventToUpdate)
-    };
-    const response = await fetch(url, requestOptions); 
-    if (!response.ok) {
-      throw new Error(`HTTP error!  ${response.status}`);
-    }
-    const data = await response.json();
-    return data;
-  }
-
-  const handleEventUpdate = ( eventID, values, startTimeOriginal, durationOriginal ) => () => {
-
-    setEventToEdit(eventID);
-
+  const handleEventUpdate = (
+    eventID,
+    values,
+    startTimeOriginal,
+    durationOriginal
+  ) => () => {
     // ToDo: Add some validation.  What kind of validation do we need?
     // ToDo: Add some update confirmation so user knows the update was successful
 
     let theUpdatedEvent = {};
 
     if (values.name) {
-      theUpdatedEvent = { 
-        ...theUpdatedEvent, 
-        name: values.name 
+      theUpdatedEvent = {
+        ...theUpdatedEvent,
+        name: values.name,
       };
     }
 
     if (values.eventType) {
-      theUpdatedEvent = { 
-        ...theUpdatedEvent, 
-        eventType: values.eventType 
+      theUpdatedEvent = {
+        ...theUpdatedEvent,
+        eventType: values.eventType,
       };
     }
 
     if (values.description) {
-      theUpdatedEvent = { 
-        ...theUpdatedEvent, 
-        description: values.description 
+      theUpdatedEvent = {
+        ...theUpdatedEvent,
+        description: values.description,
       };
     }
 
-    if (values.meetingURL) {
-      theUpdatedEvent = { 
-        ...theUpdatedEvent, 
-        videoConferenceLink: values.meetingURL 
+    if (values.videoConferenceLink) {
+      theUpdatedEvent = {
+        ...theUpdatedEvent,
+        videoConferenceLink: values.videoConferenceLink,
       };
-    }    
+    }
 
     // Set updated date to today and add it to the object
     const updatedDate = new Date().toISOString();
     theUpdatedEvent = {
-      ...theUpdatedEvent, 
-      updatedDate: updatedDate 
+      ...theUpdatedEvent,
+      updatedDate,
     };
 
     // If the day has been changed, find the next occurence of the changed day
-    if (values.dayNumber) {
-      const date = findNextOccuranceOfDay(values.dayNumber);
+    if (values.day) {
+      const date = findNextOccuranceOfDay(values.day);
       const dateGMT = new Date(date).toISOString();
 
       theUpdatedEvent = {
-        ...theUpdatedEvent, 
-        date: dateGMT
+        ...theUpdatedEvent,
+        date: dateGMT,
       };
     }
 
     // Set start time, End time and Duration if either start time or duration is changed
-    if ( values.startTime || values.duration ) {
-
+    if (values.startTime || values.duration) {
       /*
       We need a start time and a duration to calculate everything we need.  
       If only the start time or only the duration is changing, 
@@ -142,105 +99,73 @@ const EditMeetingTimes  = ({
       let startTimeToUse = startTimeOriginal;
       let durationToUse = durationOriginal;
 
-      if ( values.startTime ) {
+      if (values.startTime) {
         startTimeToUse = values.startTime;
       }
 
-      if ( values.duration ) {
+      if (values.duration) {
         durationToUse = values.duration;
       }
 
       const timeDate = timeConvertFromForm(new Date(), startTimeToUse);
-      const endTime = addDurationToTime(timeDate, durationToUse); 
+      const endTime = addDurationToTime(timeDate, durationToUse);
 
-      //convert to ISO and GMT
+      // convert to ISO and GMT
       const startTimeGMT = new Date(timeDate).toISOString();
       const endTimeGMT = new Date(endTime).toISOString();
 
-      theUpdatedEvent = { 
-        ...theUpdatedEvent, 
+      theUpdatedEvent = {
+        ...theUpdatedEvent,
         startTime: startTimeGMT,
         endTime: endTimeGMT,
-        hours: durationToUse
-      } 
+        hours: durationToUse,
+      };
     }
 
-    updateRecurringEvent(theUpdatedEvent, eventID)
-    .then( (data) => {
-      updateEventReRender(data);
-    })
-    .catch( (error) => {
-      console.log(`Update Recurring Event Error: `, error);
-      alert("Server not responding.  Please try again.");
-    });
-
-  }
-
-  /*** Delete Event Functions ***/
-  const deleteRecurringEvent = async (RecurringEventID) => {
-    const url = `/api/recurringEvents/${RecurringEventID}`;
-    const requestOptions = {
-        method: 'DELETE',
-        headers: {
-            "Content-Type": "application/json",
-            "x-customrequired-header": headerToSend
-        },
-    };
-
-    const response = await fetch(url, requestOptions); 
-    if (!response.ok) {
-      throw new Error(`HTTP error!  ${response.status}`);
-    }
-    const data = await response.json();
-    return data;
-  }
+    updateRecurringEvent(theUpdatedEvent, eventID);
+  };
 
   const handleEventDelete = (eventID) => () => {
     // ToDo: Add delete confirmation so user knows the item has been deleted
-
-    deleteRecurringEvent(eventID)
-    .then( (data) => {
-      deleteEventReRender(data);
-    })
-    .catch( (error) => {
-      console.log(`Delete Event Error: `, error);
-      alert("Server not responding.  Please try again.");
-    });
-  }
+    deleteRecurringEvent(eventID);
+  };
 
   return (
     <div>
-      <div className="project-list-heading">Project: {projectToEdit.name}</div>
+      <div className="project-list-heading">{`Project: ${projectToEdit.name}`}</div>
       <div>
-        <CreateNewEvent 
-          projectName = {projectToEdit.name}
-          projectID = {projectToEdit._id}
-          newEventReRender = {newEventReRender}
+        <CreateNewEvent
+          createNewRecurringEvent={createNewRecurringEvent}
+          projectName={projectToEdit.name}
+          // eslint-disable-next-line no-underscore-dangle
+          projectID={projectToEdit._id}
         />
       </div>
       <div className="project-list-heading">Edit Recurring Events</div>
-      {processedEvents.map(rEvent => (
+      {processedEvents.map((rEvent) => (
         <EditableMeeting
-          key = {rEvent.event_id}
-          event_id = {rEvent.event_id}
-          eventName = {rEvent.name}
-          eventDescription = {rEvent.description}
-          eventType = {rEvent.eventType}
-          eventDay = {rEvent.dayOfTheWeek}
-          eventDayNumber = {rEvent.dayOfTheWeekNumber}
-          eventStartTime = {rEvent.startTime}
-          eventEndTime = {rEvent.endTime}
-          eventDuration = {rEvent.duration}
-          eventMeetingURL = {rEvent.videoConferenceLink}
-          handleEventUpdate = {handleEventUpdate}
-          handleEventDelete = {handleEventDelete}
-         />
+          key={rEvent.event_id}
+          eventId={rEvent.event_id}
+          eventName={rEvent.name}
+          eventDescription={rEvent.description}
+          eventType={rEvent.eventType}
+          eventDayNumber={rEvent.dayOfTheWeekNumber}
+          eventStartTime={rEvent.startTime}
+          eventEndTime={rEvent.endTime}
+          eventDuration={rEvent.duration}
+          videoConferenceLink={rEvent.videoConferenceLink}
+          handleEventUpdate={handleEventUpdate}
+          handleEventDelete={handleEventDelete}
+        />
       ))}
 
-      <div><button className="button-back" onClick={goEditProject}>Back to Edit Project</button></div>
-      <div><button className="button-back" onClick={goSelectProject}>Back to Select Project</button></div>
+      <button type="button" className="button-back" onClick={goEditProject}>
+        Back to Edit Project
+      </button>
+      <button type="button" className="button-back" onClick={goSelectProject}>
+        Back to Select Project
+      </button>
     </div>
   );
-
 };
 export default EditMeetingTimes;

--- a/client/src/components/manageProjects/editProject.js
+++ b/client/src/components/manageProjects/editProject.js
@@ -15,19 +15,16 @@ const EditProject = ({
   const partnerDataFormatted = projectToEdit.partners.join(', ');
   const recrutingDataFormatted = projectToEdit.recruitingCategories.join(', ');
 
-  /* eslint-disable no-underscore-dangle */
   return (
     <div>
       <div className="project-list-heading">{`Project: ${projectToEdit.name}`}</div>
-      <div>
-        <button
-          type="button"
-          className="button-back"
-          onClick={meetingSelectClickHandler}
-        >
-          Edit Meeting Times
-        </button>
-      </div>
+      <button
+        type="button"
+        className="button-back"
+        onClick={meetingSelectClickHandler}
+      >
+        Edit Meeting Times
+      </button>
       <EditableField
         fieldData={projectToEdit.name}
         fieldName="name"
@@ -128,7 +125,6 @@ const EditProject = ({
       </button>
     </div>
   );
-  /* eslint-enable no-underscore-dangle */
 };
 
 export default EditProject;

--- a/client/src/components/manageProjects/editableMeeting.js
+++ b/client/src/components/manageProjects/editableMeeting.js
@@ -1,160 +1,79 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
+import EventForm from './eventForm';
 import '../../sass/ManageProjects.scss';
-import { createClockHours } from '../../utils/createClockHours';
 
-const EditableMeeting  = ( { 
-  event_id, 
-  eventName, 
-  eventDescription, 
-  eventType, 
-  eventDay,
+const EditableMeeting = ({
+  eventId,
+  eventName,
+  eventDescription = '',
+  eventType,
   eventDayNumber,
   eventStartTime,
-  eventEndTime, 
+  eventEndTime,
   eventDuration,
-  handleEventUpdate, 
-  handleEventDelete, 
-  eventMeetingURL 
-} ) => {
-
-  /*** Initializeation Station ***/
-  // If meetingURL or description are 'undefined', set them to an empty string
-  if (!eventMeetingURL) { eventMeetingURL = '' }
-  if (!eventDescription) { eventDescription = '' }
-
+  handleEventUpdate,
+  handleEventDelete,
+  videoConferenceLink = '',
+}) => {
+  // *** Initialization Station ***
   const initialUpdateFormValues = {
     name: `${eventName}`,
     description: `${eventDescription}`,
     eventType: `${eventType}`,
-    day: `${eventDay}`,
-    dayNumber: `${eventDayNumber}`,
+    day: `${eventDayNumber}`,
     startTime: `${eventStartTime}`,
     endTime: `${eventEndTime}`,
     duration: `${eventDuration}`,
-    meetingURL: `${eventMeetingURL}`
+    videoConferenceLink: `${videoConferenceLink}`,
   };
 
-  //One state to rule them all
-  const [formValues, setFormValues] = useState({initialUpdateFormValues});
+  // One state to rule them all
+  const [formValues, setFormValues] = useState(initialUpdateFormValues);
 
-  /*** Helper functions ***/
-
-  // create clock hours for form input
-  let clockHours = createClockHours();
+  // *** Helper functions ***
 
   // Handle form input changes
   const handleInputChange = (event) => {
-    setFormValues({ ...formValues, [event.target.name]: event.target.value })
-  }
+    setFormValues({ ...formValues, [event.target.name]: event.target.value });
+  };
 
   // Handle Clicks
-  const handleResetEvent = (eventToEditID) => () => {
-    setFormValues (initialUpdateFormValues);
-  } 
+  const handleResetEvent = () => () => {
+    setFormValues(initialUpdateFormValues);
+  };
 
   return (
-    <div className="event-form-box">
-
+    <EventForm handleInputChange={handleInputChange} formValues={formValues}>
       <div>
-        <label>Name:</label>
-        <input 
-          name='name'
-          value={formValues.name}
-          onChange={handleInputChange}
-          defaultValue={eventName}
-        />
-      </div>
-      <div>
-      <label>Meeting Type:</label>
-        <select 
-          value={formValues.eventType} 
-          onChange={handleInputChange}
-          name='eventType'
-          defaultValue={eventType}
+        <button
+          type="button"
+          className="create-form-button"
+          onClick={handleEventUpdate(
+            eventId,
+            formValues,
+            eventStartTime,
+            eventDuration
+          )}
         >
-          <option value="Team Meeting">Team Meeting</option>
-          <option value="Onboarding">Onboarding</option>
-        </select>
-      </div>
-      <div>
-        <label className="editable-field">Description:</label>
-        <input 
-          name='description'
-          value={formValues.description}
-          onChange={handleInputChange}
-          defaultValue={eventDescription}
-          placeholder='Enter event description...'
-        />
-      </div>
-      <div>
-        <label>Day:</label>
-        <select 
-          // value={formValues.day.toLowerCase()}
-          value={formValues.dayNumber} 
-          onChange={handleInputChange}
-          name='dayNumber'
-          //defaultValue={eventDay}
-          defaultValue={eventDayNumber}
-          >
-        <option value="0">Sunday</option>
-        <option value="1">Monday</option>
-        <option value="2">Tuesday</option>
-        <option value="3">Wednesday</option>
-        <option value="4">Thursday</option>
-        <option value="5">Friday</option>
-        <option value="6">Saturday</option>
-        </select>
-      </div>
-      <div>
-        <label>Start Time:</label>
-        <select 
-          value={formValues.startTime} 
-          onChange={handleInputChange}
-          name='startTime'
-          defaultValue={eventStartTime}
+          UPDATE
+        </button>
+        <button
+          type="button"
+          className="create-form-button"
+          onClick={handleResetEvent(eventId)}
         >
-        {clockHours.map((value,index) => {
-          return (
-              <option key={index} value={value}>{value}</option>
-          )})}
-        </select>
-      </div>
-      <div>
-        <label>Duration: </label>
-        <select 
-          value={formValues.duration} 
-          onChange={handleInputChange}
-          name='duration'
-          defaultValue={eventDuration}
+          RESET
+        </button>
+        <button
+          type="button"
+          className="create-form-button"
+          onClick={handleEventDelete(eventId)}
         >
-          <option value=".5">.5</option>
-          <option value="1">1</option>
-          <option value="1.5">1.5</option>
-          <option value="2">2</option>
-          <option value="2.5">2.5</option>
-          <option value="3">3</option>
-          <option value="3.5">3.5</option>
-          <option value="4">4</option>
-        </select>
+          DELETE
+        </button>
       </div>
-      <div>
-        <label>Meeting Link:</label>
-        <input 
-          value={formValues.meetingURL}
-          onChange={handleInputChange}
-          name='meetingURL'
-          defaultValue={eventMeetingURL}
-          placeholder='Enter meeting url...'
-        />
-      </div>
-      <div>
-        {/* ToDo: Redo these as 'button' rather than 'span'. Also, change class name to be more generic. */}
-        <span className="createBtn" onClick={ handleEventUpdate(event_id, formValues, eventStartTime, eventDuration) } >UPDATE</span>
-        <span className="createBtn" onClick={ handleResetEvent(event_id) }>RESET</span>
-        <span className="createBtn" onClick={ handleEventDelete(event_id) } >DELETE</span>
-      </div>
-  </div>
-  )
+    </EventForm>
+  );
 };
 
 export default EditableMeeting;

--- a/client/src/components/manageProjects/eventForm.js
+++ b/client/src/components/manageProjects/eventForm.js
@@ -1,0 +1,119 @@
+import React from 'react';
+import { createClockHours } from '../../utils/createClockHours';
+import '../../sass/ManageProjects.scss';
+
+const EventForm = ({ title, formValues, handleInputChange, children }) => {
+  /* ToDo: Ask Bonnie what, if any, validation is required */
+
+  // This creates the clock hours for the form
+  const clockHours = createClockHours();
+  return (
+    <div className="event-form-box">
+      {title && <h3 className="event-form-title">{title}</h3>}
+      <label className="event-form-label" htmlFor="name">
+        Event Name:
+        <input
+          id="name"
+          placeholder="Meeting name..."
+          name="name"
+          value={formValues.name}
+          onChange={handleInputChange}
+        />
+      </label>
+
+      <label className="event-form-label" htmlFor="eventType">
+        Event Type:
+        <select
+          id="eventType"
+          value={formValues.eventType}
+          onChange={handleInputChange}
+          name="eventType"
+        >
+          <option value="Team Meeting">Team Meeting</option>
+          <option value="Onboarding">Onboarding</option>
+        </select>
+      </label>
+
+      <label className="event-form-label" htmlFor="description">
+        Description:
+        <input
+          id="description"
+          placeholder="Meeting description..."
+          name="description"
+          value={formValues.description}
+          onChange={handleInputChange}
+        />
+      </label>
+
+      <label className="event-form-label" htmlFor="videoConferenceLink">
+        Event Link:
+        <input
+          id="videoConferenceLink"
+          placeholder="Enter meeting url..."
+          name="videoConferenceLink"
+          value={formValues.videoConferenceLink}
+          onChange={handleInputChange}
+        />
+      </label>
+
+      <label className="event-form-label" htmlFor="day">
+        Day of the Week:
+        <select
+          id="day"
+          value={formValues.day}
+          onChange={handleInputChange}
+          name="day"
+        >
+          <option value="0">Sunday</option>
+          <option value="1">Monday</option>
+          <option value="2">Tuesday</option>
+          <option value="3">Wednesday</option>
+          <option value="4">Thursday</option>
+          <option value="5">Friday</option>
+          <option value="6">Saturday</option>
+        </select>
+      </label>
+
+      <label className="event-form-label" htmlFor="startTime">
+        Start Time:
+        <select
+          id="startTime"
+          value={formValues.startTime}
+          onChange={handleInputChange}
+          name="startTime"
+        >
+          {clockHours.map((value) => {
+            return (
+              <option key={value} value={value}>
+                {value}
+              </option>
+            );
+          })}
+        </select>
+      </label>
+
+      <label className="event-form-label" htmlFor="duration">
+        Duration:
+        <select
+          id="duration"
+          value={formValues.duration}
+          onChange={handleInputChange}
+          name="duration"
+        >
+          <option value=".5">.5</option>
+          <option value="1">1</option>
+          <option value="1.5">1.5</option>
+          <option value="2">2</option>
+          <option value="2.5">2.5</option>
+          <option value="3">3</option>
+          <option value="3.5">3.5</option>
+          <option value="4">4</option>
+        </select>
+      </label>
+
+      {children}
+    </div>
+  );
+};
+
+export default EventForm;

--- a/client/src/sass/ManageProjects.scss
+++ b/client/src/sass/ManageProjects.scss
@@ -7,6 +7,25 @@
   margin-bottom: 200px;
 }
 
+.bg-overlay {
+  opacity: 0;
+  display: none;
+  &.active {
+    position: absolute;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    z-index: 1;
+    top: 0;
+    left: 0;
+    right: 0;
+    background-color: white;
+    height: 100%;
+    opacity: 0.6;
+  }
+}
+
 .project-list {
   display: flex;
   flex-direction: column;
@@ -96,7 +115,7 @@ div.editable-field {
 .event-form-box {
   min-width: 100%;
   padding: 10px;
-  margin-top: 5px;
+  margin: 5px 0;
   position: relative;
   border: solid black 2px;
   display: flex;
@@ -152,7 +171,7 @@ textarea {
 }
 
 .button-back {
-  margin-top: 0;
+  margin: 10px 0;
 }
 
 .create-form-button {


### PR DESCRIPTION
Second half of refactoring pass for https://github.com/hackforla/VRMS/issues/1041

I also added a simple loading state for manage projects/events. It's just a semi-transparant overlay with an existing loading image I found in the repo already. If we hate it, I can get rid of it, but I felt like the whole experience needed some sort of feedback while adding, updating, deleting and fetching data.

TODO:
- [x]  Create a reusable event form component (to be used by add and edit). Use on createNewEvent and editableMeeting
- [x]  Move recurring events requests from all components to corresponding api service
- [x] refactor editableMeeting
- [x] refactor editMeetingTimes
- [ ] All the actual functionality changes for https://github.com/hackforla/VRMS/issues/1041

