### PR TITLE
build: remove unused async dependency from backend-mvp-04

### DIFF
--- a/backend-mvp-04/package.json
+++ b/backend-mvp-04/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "@slack/bolt": "^2.2.3",
     "assert-env": "^0.6.0",
-    "async": "^3.2.0",
     "body-parser": "^1.19.0",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",

--- a/backend-mvp-04/yarn.lock
+++ b/backend-mvp-04/yarn.lock
@@ -1095,11 +1095,6 @@ astral-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
-async@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720"
-  integrity sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==
-
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"


### PR DESCRIPTION
dependabot detected a security issue with async, but we aren't using this in the v.4 mvp anyways, so this just removes it