### PR TITLE
docs: add wiki links to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,15 @@ VRMS is a tool used for the engagement, support, and retention of a network of v
 
 This is an ambitious project to create a system that will help us measure our human capital development, reduce repetitive tasks and processes for leadership, and improve outcomes for both volunteers and the projects they contribute to.
 
+This README is just a brief overview. Check out the [wiki](https://github.com/hackforla/VRMS/wiki/Introduction) for more information.
+
 ## Project Context
 
 We are currently in the initial planning phase after delivering a prototype to the organization's leadership. Our priorities are laying out a feature roadmap for beta and beyond, and recruiting a team of dedicated members to build the product. Time is of the essence, as each team meeting is a new opportunity to garner valuable data which, in return, supports the organization and it's members.
 
 ## Technologies
 
-This is a Full Stack web app, built with:
-
-- [React](https://reactjs.org/docs/getting-started.html)
-- [Node](https://nodejs.org/en/) / [Express](https://expressjs.com/en/starter/installing.html)
-- [MongoDB](https://docs.mongodb.com/manual/tutorial/getting-started/)
-- [Heroku](https://devcenter.heroku.com/categories/reference)
+[Technology on the VRMS Wiki](https://github.com/hackforla/VRMS/wiki/Technology)
 
 ## How to contribute
 
@@ -200,6 +197,6 @@ To view and edit the development database manually, you can download [MongoDB Co
 
 If you want to install a local copy to experiment with and learn more about MongoDB, you can use [this tutorial](https://zellwk.com/blog/local-mongodb/)
 
-### Licensing 
+### Licensing
 
- [AGPL-3.0 License](https://github.com/hackforla/VRMS/blob/development/LICENSE)
+[AGPL-3.0 License](https://github.com/hackforla/VRMS/blob/development/LICENSE)


### PR DESCRIPTION
Just added a couple minor changes to direct devs to the wiki for more info on infrastructure and the like. I also updated the technology section of the wiki with everything I've discovered about the VRMS infrastructure. Just need to find out mongo db atlas and current prod heroku info.

Nearly everything for: https://github.com/hackforla/VRMS/issues/1093