### PR TITLE
feat: route to specific project

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -20,7 +20,7 @@ import Events from './pages/Events';
 import ProjectLeaderDashboard from './pages/ProjectLeaderDashboard';
 import UserAdmin from './pages/UserAdmin';
 import ManageProjects from './pages/ManageProjects';
-import HealthCheck from "./pages/HealthCheck";
+import HealthCheck from './pages/HealthCheck';
 
 import './App.scss';
 
@@ -42,11 +42,16 @@ const routes = [
   { path: '/useradmin', name: 'useradmin', Component: UserAdmin },
   { path: '/projects', name: 'projects', Component: ManageProjects },
   {
+    path: '/project/:projectId',
+    name: 'project',
+    Component: ManageProjects,
+  },
+  {
     path: '/projectleader',
     name: 'pldashboard',
     Component: ProjectLeaderDashboard,
   },
-  { path: '/healthcheck', name: 'healthcheck', Component: HealthCheck }
+  { path: '/healthcheck', name: 'healthcheck', Component: HealthCheck },
 ];
 
 const App = () => {

--- a/client/src/components/manageProjects/editProject.js
+++ b/client/src/components/manageProjects/editProject.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import EditableField from './editableField';
 import EditMeetingTimes from './editMeetingTimes';
 import CreateNewEvent from './createNewEvent';
@@ -11,7 +12,6 @@ const EditProject = ({
   projectToEdit,
   userAccessLevel,
   updateProject,
-  goSelectProject,
   recurringEvents,
   createNewRecurringEvent,
   deleteRecurringEvent,
@@ -29,13 +29,15 @@ const EditProject = ({
 
   // Get project recurring events when component loads
   useEffect(() => {
-    setREvents(
-      recurringEvents
-        // eslint-disable-next-line no-underscore-dangle
-        .filter((e) => e?.project?._id === projectToEdit._id)
-        .map((item) => readableEvent(item))
-        .sort((a, b) => a.dayOfTheWeekNumber - b.dayOfTheWeekNumber)
-    );
+    if (recurringEvents) {
+      setREvents(
+        recurringEvents
+          // eslint-disable-next-line no-underscore-dangle
+          .filter((e) => e?.project?._id === projectToEdit._id)
+          .map((item) => readableEvent(item))
+          .sort((a, b) => a.dayOfTheWeekNumber - b.dayOfTheWeekNumber)
+      );
+    }
   }, [projectToEdit, recurringEvents, setREvents]);
 
   return (
@@ -59,9 +61,9 @@ const EditProject = ({
           setIsCreateNew={setIsCreateNew}
         />
       </div>
-      <button type="button" className="button-back" onClick={goSelectProject}>
+      <Link className="button-back" to={`/projects`}>
         Back to Select Project
-      </button>
+      </Link>
       <div className="project-list-heading">{`Project: ${projectToEdit.name}`}</div>
       <EditableField
         fieldData={projectToEdit.name}
@@ -164,7 +166,7 @@ const EditProject = ({
         <ul>
           {rEvents.map((event) => (
             // eslint-disable-next-line no-underscore-dangle
-            <li key={`${event._id}`}>
+            <li key={`${event.event_id}`}>
               <button type="button" onClick={() => setSelectedEvent(event)}>
                 <div>{event.name}</div>
                 <div className="event-list-details">{`${event.dayOfTheWeek}, ${event.startTime} - ${event.endTime}; ${event.eventType}`}</div>

--- a/client/src/components/manageProjects/selectProject.js
+++ b/client/src/components/manageProjects/selectProject.js
@@ -1,12 +1,8 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import '../../sass/ManageProjects.scss';
 
-const SelectProject = ({
-  projects,
-  accessLevel,
-  user,
-  projectSelectClickHandler,
-}) => {
+const SelectProject = ({ projects, accessLevel, user }) => {
   // If access level is 'admin', display all active projects.
   // If access level is 'user' display user managed projects.
   const managedProjects = projects
@@ -23,13 +19,9 @@ const SelectProject = ({
     .map((p) => (
       // eslint-disable-next-line no-underscore-dangle
       <li className="project-list-item" key={p._id}>
-        <button
-          className="project-list-button"
-          type="button"
-          onClick={projectSelectClickHandler(p)}
-        >
+        <Link className="project-list-button" to={`/project/${p._id}`}>
           {p.name ? p.name : '[unnamed project]'}
-        </button>
+        </Link>
       </li>
     ));
 

--- a/client/src/pages/ManageProjects.js
+++ b/client/src/pages/ManageProjects.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Redirect } from 'react-router-dom';
+import { Redirect, useParams } from 'react-router-dom';
 import useAuth from '../hooks/useAuth';
 import SelectProject from '../components/manageProjects/selectProject';
 import EditProject from '../components/manageProjects/editProject';
@@ -15,9 +15,10 @@ const PAGES = Object.freeze({
 });
 
 const ManageProjects = () => {
+  const { projectId } = useParams();
   const { auth } = useAuth();
   const [projects, setProjects] = useState();
-  const [projectToEdit, setProjectToEdit] = useState([]);
+  const [projectToEdit, setProjectToEdit] = useState();
   const [recurringEvents, setRecurringEvents] = useState();
   const [componentToDisplay, setComponentToDisplay] = useState('');
   const [projectApiService] = useState(new ProjectApiService());
@@ -83,15 +84,16 @@ const ManageProjects = () => {
 
   useEffect(() => {
     // Refresh project to edit, if projects have been refreshed
-    if (projectToEdit && projects) {
+    if (projectId && projects) {
       setProjectToEdit(
         projects.find(
           // eslint-disable-next-line no-underscore-dangle
-          (proj) => proj._id === projectToEdit._id
+          (proj) => proj._id === projectId
         )
       );
+      setComponentToDisplay(PAGES.editProjectInfo);
     }
-  }, [projectToEdit, projects, setProjectToEdit]);
+  }, [projects, setProjectToEdit, projectId]);
 
   useEffect(() => {
     fetchProjects();
@@ -103,16 +105,6 @@ const ManageProjects = () => {
     return <Redirect to="/login" />;
   }
 
-  const projectSelectClickHandler = (project) => () => {
-    setProjectToEdit(project);
-    setComponentToDisplay(PAGES.editProjectInfo);
-  };
-
-  const goSelectProject = () => {
-    setProjectToEdit([]);
-    setComponentToDisplay(PAGES.selectProject);
-  };
-
   let displayedComponent;
 
   switch (componentToDisplay) {
@@ -120,7 +112,6 @@ const ManageProjects = () => {
       displayedComponent = (
         <EditProject
           projectToEdit={projectToEdit}
-          goSelectProject={goSelectProject}
           recurringEvents={recurringEvents}
           updateProject={updateProject}
           userAccessLevel={user.accessLevel}
@@ -133,7 +124,6 @@ const ManageProjects = () => {
     default:
       displayedComponent = (
         <SelectProject
-          projectSelectClickHandler={projectSelectClickHandler}
           accessLevel={user?.accessLevel}
           projects={projects}
           user={user}

--- a/client/src/sass/ManageProjects.scss
+++ b/client/src/sass/ManageProjects.scss
@@ -275,6 +275,7 @@ textarea {
 }
 
 .button-back {
+  display: block;
   margin: 10px 0;
 }
 


### PR DESCRIPTION
Adds routing to `project/:projectId` and updates the manage projects component to display a selected project based on the projectId param.  Will update https://github.com/hackforla/VRMS/pull/1114 after this is merged to link to the relevant project

Completes the following from https://github.com/hackforla/VRMS/issues/1109

- [x]  Pass query parameter to project page indicating project id to open
- [x]  Update project page to check for query parameter and open corresponding project