### PR TITLE
Feature/add project button on projects page

### DIFF
--- a/client/src/components/manageProjects/selectProject.js
+++ b/client/src/components/manageProjects/selectProject.js
@@ -28,6 +28,12 @@ const SelectProject = ({ projects, accessLevel, user }) => {
   return (
     <div className="container--ManageProjects">
       <h3>Manage Projects</h3>
+      <div className="project-sub-heading">
+        <Link to="useradmin">
+          {' '}
+          <button>Add a Project</button>
+        </Link>
+      </div>
       <div className="project-sub-heading">Select project to edit</div>
       <ul className="project-list">{managedProjects}</ul>
     </div>

--- a/client/src/components/manageProjects/selectProject.js
+++ b/client/src/components/manageProjects/selectProject.js
@@ -28,10 +28,19 @@ const SelectProject = ({ projects, accessLevel, user }) => {
   return (
     <div className="container--ManageProjects">
       <h3>Manage Projects</h3>
-      <div className="project-sub-heading">
+      <div className="project-sub-heading" style={{ margin: '0 auto' }}>
         <Link to="useradmin">
           {' '}
-          <button>Add a Project</button>
+          <button
+            type="button"
+            className="button"
+            style={{
+              fontSize: 'small',
+              width: 'auto',
+            }}
+          >
+            Add a Project
+          </button>
         </Link>
       </div>
       <div className="project-sub-heading">Select project to edit</div>


### PR DESCRIPTION
closes #1105 

# Added button in the Manage Projects component that redirects user to the create a new project form

Created a link in the selectProject.js, below the Manage Projects h3, to the useradmin component, which houses the actual button to add a new project. 

Added provisional in-line stylings to the button in order to make it more visible while a final style is determined. 

### Issues/Questions:
Created a route to the addNewProject component that would be accessed by clicking on the button, but when entering a value in the form field I get an error in that validationMatch function. The only way I can enter new project information is if I’m in the /useradmin component route, instead of in the addNewProject route I created. I have these changes to show in my local branch. 

Will need further advice from team as to how they'd like this feature to work.  