### PR TITLE
removed two lines of code to limit particular users from editing projects

### DIFF
--- a/client/src/components/manageProjects/editProject.js
+++ b/client/src/components/manageProjects/editProject.js
@@ -114,7 +114,6 @@ const EditProject = ({
         updateProject={updateProject}
         fieldTitle="Google Drive URL:"
         accessLevel={userAccessLevel}
-        canEdit={['admin', 'user']}
       />
       <EditableField
         fieldData={projectToEdit.googleDriveId}
@@ -136,7 +135,6 @@ const EditProject = ({
         updateProject={updateProject}
         fieldTitle="Video Conference Link:"
         accessLevel={userAccessLevel}
-        canEdit={['admin', 'user']}
       />
       <EditableField
         fieldData={projectToEdit.lookingDescription}
@@ -151,7 +149,6 @@ const EditProject = ({
         updateProject={updateProject}
         fieldTitle="Partners (comma separated):"
         accessLevel={userAccessLevel}
-        canEdit={['admin', 'user']}
       />
       <EditableField
         fieldData={recrutingDataFormatted}


### PR DESCRIPTION
resolves #1143

There are 3 different levels of permissions, Admin can change everything, Limited Admin (term I made up), can only access the projects tab and can only edit meeting times, and basic users cannot access the admin portal at all.

The following screenshots are from the limited admin view.. 
<details>
    <summary>Before</summary>

![image](https://user-images.githubusercontent.com/53061723/174693113-5bf1da0e-c6f6-45ea-b3e5-5c8199333222.png)


</details>



<details>
    <summary>After</summary>

![image](https://user-images.githubusercontent.com/53061723/174693146-a6aaf0db-9399-4f61-a215-97a8ae1fd56b.png)


</details>