### PR TITLE
fix: missing body for open and close checkins

### DIFF
--- a/backend/workers/closeCheckins.js
+++ b/backend/workers/closeCheckins.js
@@ -50,7 +50,8 @@ module.exports = (cron, fetch) => {
                     headers: {
                       "Content-Type": "application/json",
                       "x-customrequired-header": headerToSend
-                    }
+                    },
+                    body: JSON.stringify({ checkInReady: false })
                 })
                     .catch(err => {
                         console.log(err);

--- a/backend/workers/openCheckins.js
+++ b/backend/workers/openCheckins.js
@@ -44,7 +44,8 @@ module.exports = (cron, fetch) => {
                     headers: {
                       "Content-Type": "application/json",
                       "x-customrequired-header": headerToSend
-                    }
+                    },
+                    body: JSON.stringify({ checkInReady: true })
                 })
                     .then(res => {
                         const response = res;


### PR DESCRIPTION
Closes: https://github.com/hackforla/VRMS/issues/1165

So, we have scheduled jobs to go through and check to see if any recurring meetings are scheduled to begin or end soon. The job fetches all the scheduled events and checks their start times. Then, if they should start or end soon, it calls the update event endpoint for each one that needs to have the checkInReady flag updated to indicate whether or not members can check in to the event.  The only thing the job doesn't do... is actually make any updates to the event record's checkInReady flag.