### PR TITLE
Adding a node version troubleshooting note to README.md 1288

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,11 +174,15 @@ This will reset the current HEAD to match the VRMS development repository.
 
    To run `client`:
 
-   - Navigate to the root of the application `vrms/` and run `npm run dev`
+   - Navigate to the root of the application `vrms/` and run `yarn start`
 
-   To run `client-mvp-04`:
+   **Troubleshooting:** If you encounter the following error after running `yarn start`:
+   
+      ```
+      Error: error:0308010C:digital envelope routines::unsupported
+      ```
+   Try changing your node version to `16.14.2` by running `nvm use 16.14.2`. If you do not have `nvm` installed, see [install instructions](https://github.com/nvm-sh/nvm#installing-and-updating)
 
-   - Navigate to the root of the application `vrms/` and run `npm run mvp`
 
 You should now have a live app. Happy hacking.
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ This will reset the current HEAD to match the VRMS development repository.
 
    - Navigate to the root of the application `vrms/` and run `yarn start`
 
-   **Troubleshooting:** If you encounter the following error after running `yarn start`:
+   *Troubleshooting :* If you encounter the following error after running `yarn start`:
    
       ```
       Error: error:0308010C:digital envelope routines::unsupported


### PR DESCRIPTION
Fixes #1288

### Changes and Why
- updated start command from `npm run dev` to `yarn start`
- removed instructions for running `client-mvp-04` to reduce confusion since this folder is not in use
- added troubleshooting instructions for how to change your node version to a version that we know plays nice with the app