### PR TITLE
feat: Resolve most front-end warnings

### DIFF
--- a/backend/workers/createRecurringEvents.js
+++ b/backend/workers/createRecurringEvents.js
@@ -45,7 +45,7 @@ module.exports = (cron, fetch) => {
     async function filterAndCreateEvents() {
         TODAY_DATE = new Date();
         TODAY = TODAY_DATE.getDay();
-        console.log("Date: ", TODAY_DATE, "Day: ", TODAY);
+        // console.log("Date: ", TODAY_DATE, "Day: ", TODAY);
         const recurringEvents = RECURRING_EVENTS;
         // console.log("Today Day: ", TODAY);
         // Filter recurring events where the event date is today
@@ -64,7 +64,7 @@ module.exports = (cron, fetch) => {
                 const eventDate = new Date(filteredEvent.date);
 
                 if (eventExists) {
-                    console.log("Not going to run ceateEvent");
+                    // console.log("Not going to run ceateEvent");
                 } else {
                     // Create new event
                     const hours = eventDate.getHours();
@@ -100,7 +100,7 @@ module.exports = (cron, fetch) => {
                     }
 
                     const created = await createEvent(eventToCreate);
-                    console.log(created);
+                    // console.log(created);
                 };
             };
         };
@@ -123,7 +123,7 @@ module.exports = (cron, fetch) => {
 
                 return (year === yearToday && month === monthToday && date === dateToday && eventName === event.name);
             });
-            console.log("Events already created: ", filteredEvents);
+            // console.log("Events already created: ", filteredEvents);
             return filteredEvents.length > 0 ? true : false;
         };
     };
@@ -140,26 +140,26 @@ module.exports = (cron, fetch) => {
                 body: jsonEvent
             }
 
-            console.log('Running createEvent: ', jsonEvent);
+            // console.log('Running createEvent: ', jsonEvent);
 
             try {
                 const response = await fetch(`${URL}/api/events/`, options);
                 const resJson = await response.json();
                 return resJson;
             } catch (error) {
-                console.log(error);
+                // console.log(error);
             };
         };
     };
 
     async function runTask() {
-        console.log("Creating today's events");
+        // console.log("Creating today's events");
 
         await fetchEvents();
         await fetchRecurringEvents();
         await filterAndCreateEvents();
 
-        console.log("Today's events are created");
+        // console.log("Today's events are created");
 
     };
 

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -1636,9 +1636,9 @@ camelize@1.0.0:
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-lite@^1.0.30001251:
-  version "1.0.30001251"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz#6853a606ec50893115db660f82c094d18f096d85"
-  integrity sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==
+  version "1.0.30001456"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001456.tgz"
+  integrity sha512-XFHJY5dUgmpMV25UqaD4kVq2LsiaU5rS8fb0f17pCoXQiQslzmFgnfOxfvo1bTpTqf7dwG/N/05CnLCnOEKmzA==
 
 capture-exit@^2.0.0:
   version "2.0.0"

--- a/client/src/components/ReadyEvents.js
+++ b/client/src/components/ReadyEvents.js
@@ -1,35 +1,33 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { REACT_APP_CUSTOM_REQUEST_HEADER } from "../utils/globalSettings";
+import { REACT_APP_CUSTOM_REQUEST_HEADER as headerToSend} from "../utils/globalSettings";
 
 import '../sass/ReadyEvents.scss';
 
 const ReadyEvents = (props) => {
     const [isLoading, setIsLoading] = useState(false);
     const [events, setEvents] = useState([]);
-    const headerToSend = REACT_APP_CUSTOM_REQUEST_HEADER;
-
-    async function fetchEvent() {
-        try {
-            setIsLoading(true);
-            const res = await fetch("/api/events?checkInReady=true", {
-                headers: {
-                    "x-customrequired-header": headerToSend
-                }
-            });
-            const resJson = await res.json();
-
-            setEvents(resJson);
-            setIsLoading(false);
-        } catch(error) {
-            console.log(error);
-            setIsLoading(false);
-        }
-    }
 
     useEffect(() => {
-        fetchEvent();
+        async function fetchEvent() {
+            try {
+                setIsLoading(true);
+                const res = await fetch("/api/events?checkInReady=true", {
+                    headers: {
+                        "x-customrequired-header": headerToSend
+                    }
+                });
+                const resJson = await res.json();
+    
+                setEvents(resJson);
+                setIsLoading(false);
+            } catch(error) {
+                console.log(error);
+                setIsLoading(false);
+            }
+        }
 
+        fetchEvent();
     }, []);
 
     return (

--- a/client/src/components/admin/dashboard/index.js
+++ b/client/src/components/admin/dashboard/index.js
@@ -10,13 +10,12 @@ import Tab from '../../../common/tabs/tab';
 import LocationTableReport from '../reports';
 import '../../../sass/Dashboard.scss';
 import './index.scss';
-import { REACT_APP_CUSTOM_REQUEST_HEADER } from '../../../utils/globalSettings';
+import { REACT_APP_CUSTOM_REQUEST_HEADER as headerToSend} from '../../../utils/globalSettings';
 
 const AdminDashboard = () => {
   const { auth } = useAuth();
   const defaultChartType = 'All Events';
   const eventsArr = [];
-  const headerToSend = REACT_APP_CUSTOM_REQUEST_HEADER;
 
   let uniqueEventTypes = new Set();
   let hackNightUniqueLocations = new Set();

--- a/client/src/components/admin/donutChartContainer.js
+++ b/client/src/components/admin/donutChartContainer.js
@@ -41,14 +41,15 @@ const DonutChartContainer = (props) => {
   }
   total = Math.round(100 * total) / 100;
 
-  const createPie = d3
-    .pie(pieData)
-    .value((d) => d.value)
-    .sort(null);
-
-  const createArc = d3.arc().innerRadius(40).outerRadius(80);
-
+  
   useEffect(() => {
+    const createPie = d3
+      .pie(pieData)
+      .value((d) => d.value)
+      .sort(null);
+  
+    const createArc = d3.arc().innerRadius(40).outerRadius(80);
+    
     const data = createPie(pieData);
 
     const group = d3.select(ref.current);
@@ -72,7 +73,7 @@ const DonutChartContainer = (props) => {
         const { data } = d;
         return data.color;
       });
-  }, [props]);
+  }, [props, pieData]);
 
   return (
     <div className="dashboard-stats">

--- a/client/src/components/auth/Auth.js
+++ b/client/src/components/auth/Auth.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Redirect } from 'react-router-dom';
 import { useHistory } from 'react-router-dom';
 import { checkUser, checkAuth } from '../../services/user.service';
@@ -88,21 +88,6 @@ const Auth = () => {
     }
   }
 
-  useEffect(() => {
-    const enterKeyEventHandler = (e) => {
-      if (e.key === 'Enter') {
-        e.preventDefault();
-        handleLogin(e);
-      }
-    };
-
-    document.addEventListener('keydown', enterKeyEventHandler);
-
-    return () => {
-      document.removeEventListener('keydown', enterKeyEventHandler);
-    };
-  }, [email]);
-
   // This allows users who are not admin, but are allowed to manage projects, to login
   let loginRedirect = '';
   if (auth?.user) {
@@ -117,7 +102,7 @@ const Auth = () => {
         <div className="adminlogin-headers">
           <h3>Welcome Back!</h3>
         </div>
-        <form className="form-check-in" autoComplete="off">
+        <form onSubmit={handleLogin} className="form-check-in" autoComplete="off">
           <div className="form-row">
             <div className="form-input-text">
               <label htmlFor="email">Enter your email address:</label>

--- a/client/src/components/auth/HandleAuth.js
+++ b/client/src/components/auth/HandleAuth.js
@@ -21,7 +21,7 @@ const HandleAuth = (props) => {
     isValidToken(api_token).then((isValid) => {
       setMagicLink(isValid)
     });
-  }, []);
+  }, [props.location.search]);
 
   // Step 2: Refresh user auth (requires valid Magic Link)
   useEffect(() => {
@@ -29,7 +29,7 @@ const HandleAuth = (props) => {
     if(!auth?.isError) return;
 
     refreshAuth();
-  },[isMagicLinkValid, refreshAuth])
+  },[isMagicLinkValid, refreshAuth, auth])
 
   // Step 3: Set IsLoaded value to render Component
   useEffect(() => {
@@ -41,7 +41,7 @@ const HandleAuth = (props) => {
     if(!auth || auth.isError) return;
     
     setIsLoaded(true);
-    },[isMagicLinkValid, auth?.isError, setIsLoaded])
+    },[isMagicLinkValid, setIsLoaded, auth])
 
   if(!isLoaded) 
     return (

--- a/client/src/components/dashboard/AttendeeTable.js
+++ b/client/src/components/dashboard/AttendeeTable.js
@@ -33,31 +33,31 @@ const AttendeeTable = ({ attendees, activeMeeting, projectId, setRoster, roster 
             .catch(error => console.log(error));
     };
 
-    function sortAttendees() {
-        if (!attendees.length || !roster.length) return;
-
-        const attendeesOnRoster = [];
-        const attendeesNotOnRoster = []; 
-              
-        attendees.map((attendee, index) => {
-            const currAttendee = { ...attendee };
-      
-            const isOnRoster = Boolean(roster.find(teamMember => 
-              teamMember.userId._id === attendee.userId._id));
-            
-            currAttendee.isOnRoster = isOnRoster;
-            isOnRoster 
-                ? attendeesOnRoster.push(currAttendee) 
-                : attendeesNotOnRoster.push(currAttendee);
-        });
-      
-        setSortedAttendees({
-            onTeam: attendeesOnRoster,
-            notOnTeam: attendeesNotOnRoster,
-        });
-    };
-
     useEffect(() => {
+        function sortAttendees() {
+            if (!attendees.length || !roster.length) return;
+    
+            const attendeesOnRoster = [];
+            const attendeesNotOnRoster = []; 
+                  
+            attendees.forEach((attendee) => {
+                const currAttendee = { ...attendee };
+          
+                const isOnRoster = Boolean(roster.find(teamMember => 
+                  teamMember.userId._id === attendee.userId._id));
+                
+                currAttendee.isOnRoster = isOnRoster;
+                isOnRoster 
+                    ? attendeesOnRoster.push(currAttendee) 
+                    : attendeesNotOnRoster.push(currAttendee);
+            });
+          
+            setSortedAttendees({
+                onTeam: attendeesOnRoster,
+                notOnTeam: attendeesNotOnRoster,
+            });
+        };
+        
         sortAttendees();
     }, [attendees, roster]);
 

--- a/client/src/components/dashboard/RosterTable.js
+++ b/client/src/components/dashboard/RosterTable.js
@@ -51,8 +51,6 @@ const RosterTable = ({ attendees, activeMeeting, RosterProjectId }) => {
   };
 
   const gDriveClickHandler = (email, fileId) => {
-    email = email;
-    fileId = fileId;
     const bodyObject = {
       email: email,
       file: fileId,
@@ -79,6 +77,7 @@ const RosterTable = ({ attendees, activeMeeting, RosterProjectId }) => {
       });
   };
 
+  // eslint-disable-next-line
   const gitHubClickHandler = (
     githubHandle,
     projectName,

--- a/client/src/components/manageProjects/editProject.js
+++ b/client/src/components/manageProjects/editProject.js
@@ -20,6 +20,7 @@ const EditProject = ({
 }) => {
   // Add commas to arrays for display
   const partnerDataFormatted = projectToEdit.partners.join(', ');
+  // eslint-disable-next-line
   const recrutingDataFormatted = projectToEdit.recruitingCategories.join(', ');
   const [rEvents, setREvents] = useState([]);
   const [selectedEvent, setSelectedEvent] = useState();

--- a/client/src/components/manageProjects/utilities/addDurationToTime.js
+++ b/client/src/components/manageProjects/utilities/addDurationToTime.js
@@ -30,7 +30,7 @@ export const addDurationToTime = (startTimeDate, duration) => {
 			endTime = new Date(date.getTime() + (4*3600000));
 		break;
 		default:
-			throw 'Error: Cannot calculate endTime';
+			throw new Error('Error: Cannot calculate endTime');
 	} 
 	return endTime;
 };

--- a/client/src/pages/CheckInForm.js
+++ b/client/src/pages/CheckInForm.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import moment from 'moment';
 import NewUserForm from './../components/presentational/newUserForm';
 import ReturnUserForm from './../components/presentational/returnUserForm';
-import { REACT_APP_CUSTOM_REQUEST_HEADER } from '../utils/globalSettings';
+import { REACT_APP_CUSTOM_REQUEST_HEADER as headerToSend } from '../utils/globalSettings';
 
 import '../sass/CheckIn.scss';
 
@@ -74,7 +74,6 @@ const CheckInForm = (props) => {
     'Fundraising',
   ];
 
-  const headerToSend = REACT_APP_CUSTOM_REQUEST_HEADER;
 
   const fetchQuestions = async () => {
     try {
@@ -129,7 +128,6 @@ const CheckInForm = (props) => {
 
   const submitForm = async (userForm) => {
     // First, create a new user in the user collection
-    const headerToSend = REACT_APP_CUSTOM_REQUEST_HEADER;
 
     const userRes = await fetch('/api/users', {
       method: 'POST',
@@ -185,7 +183,6 @@ const CheckInForm = (props) => {
     const answerJson = JSON.stringify(answer);
 
     try {
-      const headerToSend = REACT_APP_CUSTOM_REQUEST_HEADER;
       fetch(`/api/users/${returningUser.user._id}`, {
         method: 'PATCH',
         body: answerJson,
@@ -246,7 +243,6 @@ const CheckInForm = (props) => {
 
   const submitNewProfile = (userForm) => {
     // First, create a new user in the user collection
-    const headerToSend = REACT_APP_CUSTOM_REQUEST_HEADER;
 
     fetch('/api/users', {
       method: 'POST',

--- a/client/src/pages/EmailSent.js
+++ b/client/src/pages/EmailSent.js
@@ -10,7 +10,7 @@ const EmailSent = (props) => {
         }, 10000);
 
         return () => clearTimeout(timer);
-    }, []);
+    }, [props.history]);
 
     return (
         <div className="flex-container">

--- a/client/src/pages/Event.js
+++ b/client/src/pages/Event.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import moment from 'moment';
-import { REACT_APP_CUSTOM_REQUEST_HEADER } from '../utils/globalSettings';
+import { REACT_APP_CUSTOM_REQUEST_HEADER as headerToSend } from '../utils/globalSettings';
 
 import '../sass/Event.scss';
 
@@ -9,24 +9,8 @@ const Event = (props) => {
   const [isLoading, setIsLoading] = useState(false);
   const [event, setEvent] = useState([]);
   const [isCheckInReady, setIsCheckInReady] = useState();
-  const headerToSend = REACT_APP_CUSTOM_REQUEST_HEADER;
 
-  async function fetchEvent() {
-    try {
-      const res = await fetch(`/api/events/${props.match.params.id}`, {
-        headers: {
-          'x-customrequired-header': headerToSend,
-        },
-      });
-      const resJson = await res.json();
-
-      setEvent(resJson);
-      setIsCheckInReady(resJson.checkInReady);
-    } catch (error) {
-      console.log(error);
-    }
-  }
-
+  // eslint-disable-next-line
   async function setCheckInReady(e) {
     e.preventDefault();
 
@@ -49,8 +33,24 @@ const Event = (props) => {
   }
 
   useEffect(() => {
+    async function fetchEvent() {
+      try {
+        const res = await fetch(`/api/events/${props.match.params.id}`, {
+          headers: {
+            'x-customrequired-header': headerToSend,
+          },
+        });
+        const resJson = await res.json();
+  
+        setEvent(resJson);
+        setIsCheckInReady(resJson.checkInReady);
+      } catch (error) {
+        console.log(error);
+      }
+    }
+
     fetchEvent();
-  }, [isLoading, isCheckInReady]);
+  }, [isLoading, isCheckInReady, props.match.params.id]);
 
   return (
     <div className="flex-container">

--- a/client/src/pages/Events.js
+++ b/client/src/pages/Events.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link, Redirect } from 'react-router-dom';
 import moment from 'moment';
-import { REACT_APP_CUSTOM_REQUEST_HEADER } from '../utils/globalSettings';
+import { REACT_APP_CUSTOM_REQUEST_HEADER as headerToSend} from '../utils/globalSettings';
 
 import '../sass/Events.scss';
 import useAuth from '../hooks/useAuth';
@@ -10,24 +10,23 @@ const Events = (props) => {
   const { auth } = useAuth();
   const [events, setEvents] = useState([]);
   const [eventSearchParam, setEventSearchParam] = useState('');
-  const headerToSend = REACT_APP_CUSTOM_REQUEST_HEADER;
-
-  async function fetchData() {
-    try {
-      const res = await fetch('/api/events', {
-        headers: {
-          'x-customrequired-header': headerToSend,
-        },
-      });
-      const resJson = await res.json();
-
-      setEvents(resJson);
-    } catch (error) {
-      alert(error);
-    }
-  }
 
   useEffect(() => {
+    async function fetchData() {
+      try {
+        const res = await fetch('/api/events', {
+          headers: {
+            'x-customrequired-header': headerToSend,
+          },
+        });
+        const resJson = await res.json();
+  
+        setEvents(resJson);
+      } catch (error) {
+        alert(error);
+      }
+    }
+    
     fetchData();
   }, []);
 
@@ -48,10 +47,6 @@ const Events = (props) => {
             );
           })
           .map((event, index) => {
-            const event_city = event.location && (event.location.city || 'TBD');
-            const event_state =
-              event.location && (event.location.state || 'TBD');
-
             return (
               <li key={index}>
                 <div key={index} className="list-event-container">

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import CheckInButtons from "../components/presentational/CheckInButtons";
 import CreateNewProfileButton from "../components/presentational/CreateNewProfileButton";
-import { REACT_APP_CUSTOM_REQUEST_HEADER } from "../utils/globalSettings";
+import { REACT_APP_CUSTOM_REQUEST_HEADER as headerToSend } from "../utils/globalSettings";
 
 import "../sass/Home.scss";
 
@@ -10,7 +10,6 @@ const Home = (props) => {
     // eslint-disable-next-line no-unused-vars
     const [isLoading, setIsLoading] = useState(false);
     const [event, setEvent] = useState("--SELECT ONE--");
-    const headerToSend = REACT_APP_CUSTOM_REQUEST_HEADER;
 
     async function fetchEvents() {
         try {
@@ -83,8 +82,7 @@ const Home = (props) => {
                 {events.length > 0 && (
                     <div className="home-buttons">
                         {event === "--SELECT ONE--" && events.length === 1 && <CreateNewProfileButton />}
-                        {event !== "--SELECT ONE--" && events.length > 1 && <CheckInButtons event={event} events={events} />}
-                        {event === "--SELECT ONE--" && events.length > 1 && <CheckInButtons disabled={true} event={event} events={events}/>}
+                        {events.length > 1 && <CheckInButtons disabled={event === "--SELECT ONE--"} event={event} events={events}/>}
                     </div>
                 )}
             </div>

--- a/client/src/pages/ProjectLeaderDashboard.js
+++ b/client/src/pages/ProjectLeaderDashboard.js
@@ -4,7 +4,7 @@ import UpcomingEvent from "../components/presentational/upcomingEvent";
 import ProjectDashboardContainer from "../components/presentational/projectDashboardContainer";
 import DashboardButton from "../components/dashboard/DashboardButton";
 import ProjectInfo from "../components/dashboard/ProjectInfo";
-import { REACT_APP_CUSTOM_REQUEST_HEADER } from "../utils/globalSettings";
+import { REACT_APP_CUSTOM_REQUEST_HEADER as headerToSend } from "../utils/globalSettings";
 
 import "../sass/Dashboard.scss";
 
@@ -21,88 +21,6 @@ const ProjectLeaderDashboard = () => {
   const [errorMessage, setErrorMessage] = useState("");
   const [isSuccess, setIsSuccess] = useState(false);
   const [rosterProjectId, setRosterProjectId] = useState("");
-  const headerToSend = REACT_APP_CUSTOM_REQUEST_HEADER;
-
-  async function getProjectFromUserId() {
-    try {
-      const project = await fetch(
-        "/api/projectteammembers/projectowner/5e2790b06dc5b4ed0bc1df56", {
-            headers: {
-                "x-customrequired-header": headerToSend
-            }
-        }
-      );
-      const projectJson = await project.json();
-      setProject(projectJson);
-    } catch (error) {
-      console.log(error);
-    }
-  }
-
-  async function getNextEvent() {
-    // event id temporarily hard coded so actual check in data would be listed
-    try {
-      if (project && project.projectId) {
-        const events = await fetch(
-          `/api/events/nexteventbyproject/${project.projectId._id}`, {
-            headers: {
-                "x-customrequired-header": headerToSend
-            }
-          } 
-        );
-        const eventsJson = await events.json();
-        setIsCheckInReady(eventsJson.checkInReady);
-        setNextEvent([eventsJson]);
-      }
-    } catch (err) {
-      console.log(err);
-    }
-  }
-
-  async function getRoster() {
-    try {
-      if (project && project.projectId) {
-        const roster = await fetch(
-          `/api/projectteammembers/${project.projectId._id}`, {
-              headers: {
-                  "x-customrequired-header": headerToSend
-              }
-          }
-        );
-        const rosterJson = await roster.json();
-        // temporary function that fixes outdated data
-        rosterJson.forEach((item) => {
-          if (!item.userId.name) {
-            item.userId.name = {};
-            item.userId.name.firstName = item.userId.firstName;
-            item.userId.name.lastName = item.userId.lastName; 
-          }
-        });
-        setRoster(rosterJson);
-
-        setRosterProjectId(project.projectId.googleDriveId);
-      }
-    } catch (error) {
-      console.log(error);
-    }
-  }
-
-  async function getAttendees() {
-    try {
-      if (nextEvent && nextEvent[0]._id) {
-        const id = nextEvent[0]._id;
-        const attendees = await fetch(`/api/checkins/findEvent/${id}`, {
-            headers: {
-                "x-customrequired-header": headerToSend
-            }
-          });
-        const attendeesJson = await attendees.json();
-        setAttendees(attendeesJson);
-      }
-    } catch (error) {
-      console.log(error);
-    }
-  }
 
   async function setCheckInReady(e, nextEventId) {
     e.preventDefault();
@@ -125,10 +43,6 @@ const ProjectLeaderDashboard = () => {
 
   async function changeTable(e) {
     setAttendeeOrRoster(e);
-  }
-
-  async function getDashboardInfo() {
-    await getProjectFromUserId();
   }
 
   const handleSubmit = async (e, email) => {
@@ -193,10 +107,10 @@ const ProjectLeaderDashboard = () => {
     try {
       const onTeam = await fetch(
         `/api/projectteammembers/project/${project.projectId._id}/${user._id}`, {
-          headers: {
-            "x-customrequired-header": headerToSend
-          }
+        headers: {
+          "x-customrequired-header": headerToSend
         }
+      }
       );
       const onTeamJson = await onTeam.json();
 
@@ -241,18 +155,99 @@ const ProjectLeaderDashboard = () => {
   }
 
   useEffect(() => {
-    getDashboardInfo();
+    async function getProjectFromUserId() {
+      try {
+        const project = await fetch(
+          "/api/projectteammembers/projectowner/5e2790b06dc5b4ed0bc1df56", {
+          headers: {
+            "x-customrequired-header": headerToSend
+          }
+        }
+        );
+        const projectJson = await project.json();
+        setProject(projectJson);
+      } catch (error) {
+        console.log(error);
+      }
+    }
+
+    getProjectFromUserId() // getDashboardInfo
   }, []);
 
   useEffect(() => {
+    async function getAttendees() {
+      try {
+        if (nextEvent && nextEvent[0]._id) {
+          const id = nextEvent[0]._id;
+          const attendees = await fetch(`/api/checkins/findEvent/${id}`, {
+            headers: {
+              "x-customrequired-header": headerToSend
+            }
+          });
+          const attendeesJson = await attendees.json();
+          setAttendees(attendeesJson);
+        }
+      } catch (error) {
+        console.log(error);
+      }
+    }
+    
     getAttendees();
   }, [nextEvent]);
 
   useEffect(() => {
+    async function getRoster() {
+      try {
+        if (project && project.projectId) {
+          const roster = await fetch(
+            `/api/projectteammembers/${project.projectId._id}`, {
+            headers: {
+              "x-customrequired-header": headerToSend
+            }
+          }
+          );
+          const rosterJson = await roster.json();
+          // temporary function that fixes outdated data
+          rosterJson.forEach((item) => {
+            if (!item.userId.name) {
+              item.userId.name = {};
+              item.userId.name.firstName = item.userId.firstName;
+              item.userId.name.lastName = item.userId.lastName;
+            }
+          });
+          setRoster(rosterJson);
+  
+          setRosterProjectId(project.projectId.googleDriveId);
+        }
+      } catch (error) {
+        console.log(error);
+      }
+    }
+    
     getRoster();
   }, [project, forceRerender]);
 
   useEffect(() => {
+    async function getNextEvent() {
+      // event id temporarily hard coded so actual check in data would be listed
+      try {
+        if (project && project.projectId) {
+          const events = await fetch(
+            `/api/events/nexteventbyproject/${project.projectId._id}`, {
+            headers: {
+              "x-customrequired-header": headerToSend
+            }
+          }
+          );
+          const eventsJson = await events.json();
+          setIsCheckInReady(eventsJson.checkInReady);
+          setNextEvent([eventsJson]);
+        }
+      } catch (err) {
+        console.log(err);
+      }
+    }
+    
     getNextEvent();
   }, [project]);
 

--- a/client/src/pages/ReturningUser.js
+++ b/client/src/pages/ReturningUser.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 
 import ReadyEvents from '../components/ReadyEvents';
 

--- a/client/src/pages/Success.js
+++ b/client/src/pages/Success.js
@@ -12,9 +12,9 @@ const Success = (props) => {
           <h4 className="last-row">Soon, you'll be able to: </h4>
         </div>
         <div className="future-list">
-          <p>👉 View your detailed, personalized journey...</p>
-          <p>👉 Get matched with projects that need you...</p>
-          <p>👉 Manage your own project!</p>
+          <p><span role="img" aria-label="pointing finger">👉</span> View your detailed, personalized journey...</p>
+          <p><span role="img" aria-label="pointing finger">👉</span> Get matched with projects that need you...</p>
+          <p><span role="img" aria-label="pointing finger">👉</span> Manage your own project!</p>
         </div>
 
         <div className="success-info">

--- a/client/src/pages/UserDashboard.js
+++ b/client/src/pages/UserDashboard.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
 const UserDashboard = (props) => (
   <div className="flex-container">

--- a/client/src/pages/UserProfile.js
+++ b/client/src/pages/UserProfile.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import '../sass/UserProfile.scss';
 import UserTable from '../components/presentational/profile/UserTable';
 import UserEvents from '../components/presentational/profile/UserEvents';

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -3381,9 +3381,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001135:
-  version "1.0.30001148"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001148.tgz#dc97c7ed918ab33bf8706ddd5e387287e015d637"
-  integrity sha512-E66qcd0KMKZHNJQt9hiLZGE3J4zuTqE1OnU53miEVtylFbwOEmeA5OsRu90noZful+XGSQOni1aT2tiqu/9yYw==
+  version "1.0.30001456"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001456.tgz"
+  integrity sha512-XFHJY5dUgmpMV25UqaD4kVq2LsiaU5rS8fb0f17pCoXQiQslzmFgnfOxfvo1bTpTqf7dwG/N/05CnLCnOEKmzA==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fixes #1068 

### What changes did you make and why did you make them ?

Front end compiles with many warnings, this removes all but one of them at time of writing.

A few of the resolutions are //disable-next-line while we figure out if we want to drop some of the older features.

## Changes

<details>
<summary>Squashed Commit Messages:</summary>

asset: Update caniuse

fix: Remove useEffect from Auth, add onSubmit

Resolve Warning:
* Line 104:6:  React Hook useEffect has a missing dependency: 'handleLogin'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

fix: Add props.history to useEffect dep array

* Resolves Line 13:8:  React Hook useEffect has a missing dependency: 'props.history'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

fix: Add span and aria-label to eomji

fix: Remove useEffect, resolve no-unused-vars

in components:
* UserDashboard
* UserProfile
* ReturningUser
* Auth

fix: Add eslint ignore to recrutingDataFormatted

Code it references is currently commented out
Preserve until decision is made on to remove it or not

fix: Resolve no-self-assign warning in RosterTable

fix: Add ignore rule for gitHubClickHandler

fix: Remove unused vars event_city and event_state

fix: Add ignore rule for setCheckInReady

fix: Change .map to .forEach, no return needed

fix: Resolve no-throw-literal using new Error()

fix: Comment out console.log for backend

fix: Move true/false to prop vs new component

fix: Refactor single use fetch inside useEffect

Move fetch functions into useEffect to resolve react-hooks/exhaustive-deps

fix: Add props.location.search to deps array

Resolve react-hooks/exhaustive-deps

fix: Add auth to useEffect deps array

fix: Move fetch inside useEffect for eslint

* Add props to deps array to resolve react-hook/exhaustive-deps Resolves react-hooks/exhaustive-deps

fix: Move fetch inside useEffect for eslint

fix: Move fetch inside useEffect for eslint

fix: Rename headersToSend in import

Resolves warning for deps array, headersToSend is now defined outside the scope of the react component.

fix: Rename headersToSend in import

fix: Rename headersToSend in import

fix: Rename headersToSend in import

fix: Rename headersToSend in import

fix: Rename headersToSend in import

fix: Rename headersToSend in import

fix: Update useEffect react-hooks/exhastive-deps

Move single use functions inside useEffect
Add pieData to deps array

fix: Move single use function inside useEffect

Resolves react-hooks/ehxaustive-deps

</details>

<details>
<summary>Changes Before:</summary>
<img width="717" alt="image" src="https://user-images.githubusercontent.com/5898009/221392637-146cae6f-0ac8-4ae1-a57a-30e4a09dea4c.png">

</details>


<details>
<summary>Changes After:</summary>
<img width="717" alt="image" src="https://user-images.githubusercontent.com/5898009/221392602-bd7c3f1c-096b-4d93-9020-766246ac8b1e.png">
</details>