### PR TITLE
Fix github action ubuntu brownout

### DIFF
--- a/.github/workflows/all-PRs.yaml
+++ b/.github/workflows/all-PRs.yaml
@@ -22,7 +22,7 @@ jobs:
         run: docker-compose run --rm backend yarn run test --testPathIgnorePatterns=routers
 
   test-backend-integration:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Make envfile


### PR DESCRIPTION
Fixes #1314

### What changes did you make and why did you make them ?

  - Updated `runs-on` for `test-backend-integeration` job because of ubuntu brownout 


