### PR TITLE
Remove default initial value for name input of event form

### DIFF
--- a/client/src/components/manageProjects/createNewEvent.js
+++ b/client/src/components/manageProjects/createNewEvent.js
@@ -15,7 +15,7 @@ const CreateNewEvent = ({
 }) => {
   // These are the initial form values
   const initialFormValues = {
-    name: `${projectName} Team Meeting`,
+    name: '',
     eventType: 'Team Meeting',
     description: '',
     videoConferenceLink: '',
@@ -77,10 +77,10 @@ const CreateNewEvent = ({
       handleEventCreate();
       setFormValues(initialFormValues);
       setIsCreateNew(false);
-      setEventAlert("Event created!")
+      setEventAlert('Event created!');
       await setTimeout(() => {
         setEventAlert(null);
-      }, 5000)
+      }, 5000);
     }
     setFormErrors(errors);
   };


### PR DESCRIPTION
Fixes #1355

### What changes did you make and why did you make them ?
  - Removed the default value from `initialFormValues.name` so that users will be forced to enter a meeting name


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://user-images.githubusercontent.com/73561520/226694651-1dd0fee1-466f-4a3b-93df-04436a32d1f2.png)


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://user-images.githubusercontent.com/73561520/226694811-f6fb14e8-a292-44ef-adea-62a8486f5ed5.png)

</details>
