### PR TITLE
Add welcome landing page with wiki link for admin and project managers

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -22,6 +22,7 @@ import UserAdmin from './pages/UserAdmin';
 import ProjectList from './pages/ProjectList';
 import ManageProjects from './pages/ManageProjects';
 import HealthCheck from './pages/HealthCheck';
+import UserWelcome from './pages/UserWelcome';
 
 import ProjectForm from './components/ProjectForm';
 
@@ -59,6 +60,7 @@ const routes = [
     Component: ProjectLeaderDashboard,
   },
   { path: '/healthcheck', name: 'healthcheck', Component: HealthCheck },
+  { path: '/welcome', name: 'welcome', Component: UserWelcome },
 ];
 
 const App = () => {

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -27,11 +27,20 @@ const Navbar = (props) => {
   });
 
   return (
-    <Box sx={{ width: '100%', typography: 'body 1', mt: 2, mb: 2 }}>
+    <Box sx={{ my: 2, mx: { xs: 0, sm: 4 } }}>
       <Grid container>
+        <Grid item>
+          <NavLink to={!auth?.user ? '/' : '/welcome'}>
+            <Box
+              component="img"
+              src={HflaImg}
+              sx={{ width: '48.3px', mt: '7px' }}
+            />
+          </NavLink>
+        </Grid>
         <Grid
           item
-          xs={9}
+          xs={10}
           sx={{
             display: 'flex',
             justifyContent: 'space-evenly',
@@ -71,11 +80,6 @@ const Navbar = (props) => {
               </StyledButton>
             </>
           )}
-        </Grid>
-        <Grid item>
-          <NavLink to={!auth?.user ? '/' : '/welcome'}>
-            <Box component="img" src={HflaImg} sx={{ width: '100%' }} />
-          </NavLink>
         </Grid>
       </Grid>
     </Box>

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -9,7 +9,7 @@ import theme from '../theme';
 const Navbar = (props) => {
   // check user accessLevel and adjust link accordingly
   const { auth } = useAuth();
- 
+
   const StyledButton = styled(Button)({
     color: '#757575',
     padding: '6px 0',
@@ -27,45 +27,56 @@ const Navbar = (props) => {
   });
 
   return (
-        <Box sx={{ width: '100%', typography: 'body 1', mt: 2, mb: 2 }}>
-          <Grid container>
-            <Grid item xs={9} sx={{ display: 'flex', justifyContent: 'space-evenly', alignItems: 'center'}}>
-              {/* No auth page -> Displays 2 links -> 'Checkin' and 'Admin'. */}
-              {!auth?.user && (
-                <>
-                  <StyledButton component={NavLink} exact to="/">
-                    CHECK IN
-                  </StyledButton>
-                  <StyledButton component={NavLink} to="/login">
-                    ADMIN
-                  </StyledButton>
-                </>
-              )}
-              {/* Admin auth -> Displays 2 links -> 'Users' and 'Projects'. */}
-              {auth?.user?.accessLevel === 'admin' && (
-                <>
-                  <StyledButton component={NavLink} to="/useradmin">
-                    USERS
-                  </StyledButton>
-                  <StyledButton component={NavLink} to="/projects">
-                    PROJECTS
-                  </StyledButton>
-                </>
-              )}
-              {/* User auth -> Displays 1 link -> 'Projects' only. */}
-              {auth?.user?.accessLevel === 'user' && (
-                <>
-                  <StyledButton component={NavLink} to="/projects">
-                    PROJECTS
-                  </StyledButton>
-                </>
-              )}
-            </Grid>
-            <Grid item>
-              <Box component="img" src={HflaImg} sx={{ width: '100%' }} />
-            </Grid>
-          </Grid>
-        </Box>
+    <Box sx={{ width: '100%', typography: 'body 1', mt: 2, mb: 2 }}>
+      <Grid container>
+        <Grid
+          item
+          xs={9}
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-evenly',
+            alignItems: 'center',
+          }}
+        >
+          {/* No auth page -> Displays 2 links -> 'Checkin' and 'Admin'. */}
+          {!auth?.user && (
+            <>
+              <StyledButton component={NavLink} exact to="/">
+                CHECK IN
+              </StyledButton>
+              <StyledButton component={NavLink} to="/login">
+                ADMIN
+              </StyledButton>
+            </>
+          )}
+          {/* Admin auth -> Displays 2 links -> 'Users' and 'Projects'. */}
+          {auth?.user?.accessLevel === 'admin' && (
+            <>
+              <StyledButton component={NavLink} to="/useradmin">
+                USERS
+              </StyledButton>
+              <StyledButton component={NavLink} to="/projects">
+                PROJECTS
+              </StyledButton>
+              <StyledButton component={NavLink} to="/admin">
+                STATS
+              </StyledButton>
+            </>
+          )}
+          {/* User auth -> Displays 1 link -> 'Projects' only. */}
+          {auth?.user?.accessLevel === 'user' && (
+            <>
+              <StyledButton component={NavLink} to="/projects">
+                PROJECTS
+              </StyledButton>
+            </>
+          )}
+        </Grid>
+        <Grid item>
+          <Box component="img" src={HflaImg} sx={{ width: '100%' }} />
+        </Grid>
+      </Grid>
+    </Box>
   );
 };
 

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -73,7 +73,9 @@ const Navbar = (props) => {
           )}
         </Grid>
         <Grid item>
-          <Box component="img" src={HflaImg} sx={{ width: '100%' }} />
+          <NavLink to={!auth?.user ? '/' : '/welcome'}>
+            <Box component="img" src={HflaImg} sx={{ width: '100%' }} />
+          </NavLink>
         </Grid>
       </Grid>
     </Box>

--- a/client/src/context/authContext.js
+++ b/client/src/context/authContext.js
@@ -1,58 +1,59 @@
 import React, { createContext, useState, useEffect } from 'react';
-import { REACT_APP_CUSTOM_REQUEST_HEADER as headerToSend} from "../utils/globalSettings";
+import { REACT_APP_CUSTOM_REQUEST_HEADER as headerToSend } from '../utils/globalSettings';
 import * as authApi from '../api/auth';
+import { useHistory } from 'react-router-dom';
 
 export const AuthContext = createContext();
 
 export const AuthProvider = ({ children }) => {
-    const [auth, setAuth] = useState();
+  const [auth, setAuth] = useState();
+  const history = useHistory();
 
-    useEffect(() => {
-      refreshAuth();
-    }, []);
+  useEffect(() => {
+    refreshAuth();
+  }, []);
 
-    const refreshAuth = async () => {
-      const userAuth = await fetchAuth();
-      setAuth(userAuth)
+  const refreshAuth = async () => {
+    const userAuth = await fetchAuth();
+    setAuth(userAuth);
+  };
+
+  const logout = async () => {
+    const res = await authApi.fetchLogout();
+
+    if (!res.ok) {
+      throw new Error(res.statusText);
     }
 
-    const logout = async () => {
-      const res = await authApi.fetchLogout();
+    history.push('/');
+    setAuth(null);
+  };
 
-      if (!res.ok) {
-        throw new Error(res.statusText);
-      }
-
-      setAuth(null);
-    }
-    
-    return (
-        <AuthContext.Provider value={{auth, refreshAuth, logout}}>
-            { children }
-        </AuthContext.Provider>
-    );
+  return (
+    <AuthContext.Provider value={{ auth, refreshAuth, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
 };
 
 const fetchAuth = async () => {
-
   const request = {
-    method: "POST",
+    method: 'POST',
     headers: {
-      "Content-Type": "application/json",
-      "x-customrequired-header": headerToSend
+      'Content-Type': 'application/json',
+      'x-customrequired-header': headerToSend,
     },
   };
 
-  try{
-    const response = await fetch("/api/auth/me", request);
-    if(response.status !== 200)
-      return {user: null, isAdmin: false, isError: true };
+  try {
+    const response = await fetch('/api/auth/me', request);
+    if (response.status !== 200)
+      return { user: null, isAdmin: false, isError: true };
 
-    const user = await response.json();  
+    const user = await response.json();
     return { user, isAdmin: user.accessLevel === 'admin', isError: false };
-  }
-  catch (error) {
+  } catch (error) {
     // this should never be hit...
-    console.error("fetchAuth - error", error);
+    console.error('fetchAuth - error', error);
   }
-}
+};

--- a/client/src/pages/UserWelcome.js
+++ b/client/src/pages/UserWelcome.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Typography, Box, Button, Link } from '@mui/material';
+import { Typography, Box, Link } from '@mui/material';
 import useAuth from '../hooks/useAuth';
 
 export default function UserWelcome() {

--- a/client/src/pages/UserWelcome.js
+++ b/client/src/pages/UserWelcome.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Typography, Box, Button, Link } from '@mui/material';
+import useAuth from '../hooks/useAuth';
+
+export default function UserWelcome() {
+  const { auth } = useAuth();
+
+  const user = auth?.user;
+
+  const firstName = user?.name.firstName;
+
+  console.log('AUTH', auth);
+  return (
+    <Box textAlign="center" sx={{ pt: 5 }}>
+      <Typography variant="h1">Greetings {firstName}!</Typography>
+      <Typography variant="p">
+        Welcome to the Volunteer Relationship Managment System. For assistance,
+        please see the{' '}
+      </Typography>
+      <Link
+        target="_blank"
+        href="https://github.com/hackforla/VRMS/wiki/User-Guide"
+        color="secondary"
+        sx={{ fontFamily: 'aliseoregular' }}
+      >
+        User Guide Wiki
+      </Link>
+    </Box>
+  );
+}

--- a/client/src/pages/UserWelcome.js
+++ b/client/src/pages/UserWelcome.js
@@ -12,19 +12,20 @@ export default function UserWelcome() {
   console.log('AUTH', auth);
   return (
     <Box textAlign="center" sx={{ pt: 5 }}>
-      <Typography variant="h1">Greetings {firstName}!</Typography>
-      <Typography variant="p">
-        Welcome to the Volunteer Relationship Managment System. For assistance,
-        please see the{' '}
-      </Typography>
-      <Link
-        target="_blank"
-        href="https://github.com/hackforla/VRMS/wiki/User-Guide"
-        color="secondary"
-        sx={{ fontFamily: 'aliseoregular' }}
-      >
-        User Guide Wiki
-      </Link>
+      <Typography variant="h1">Welcome {firstName}!</Typography>
+      <Box sx={{ fontSize: '16px' }}>
+        <Typography variant="p">
+          For assistance using VRMS, check out the{' '}
+        </Typography>
+        <Link
+          target="_blank"
+          href="https://github.com/hackforla/VRMS/wiki/User-Guide"
+          color="secondary"
+          sx={{ fontFamily: 'aliseoregular' }}
+        >
+          User Guide
+        </Link>
+      </Box>
     </Box>
   );
 }

--- a/client/src/utils/authUtils.js
+++ b/client/src/utils/authUtils.js
@@ -7,7 +7,7 @@ export function authLevelRedirect(user) {
       loginRedirect = '/welcome';
       break;
     case 'user':
-      loginRedirect = '/projects';
+      loginRedirect = '/welcome';
       break;
     default:
     // Do nothing (harder than you think).

--- a/client/src/utils/authUtils.js
+++ b/client/src/utils/authUtils.js
@@ -1,19 +1,17 @@
-export function authLevelRedirect (user) {
-
+export function authLevelRedirect(user) {
   let loginRedirect;
   let userAccessLevel = user.accessLevel;
 
   switch (userAccessLevel) {
     case 'admin':
-      loginRedirect = '/admin';
+      loginRedirect = '/welcome';
       break;
     case 'user':
-      loginRedirect = '/projects'
+      loginRedirect = '/projects';
       break;
     default:
-      // Do nothing (harder than you think).
+    // Do nothing (harder than you think).
   }
 
   return loginRedirect;
 }
-


### PR DESCRIPTION
Fixes #1353

### What changes did you make and why did you make them ?
  - Added a welcome page so that we can provide users with a link to the wiki page explaining how to use the app
  - Added `STATS` option to navbar so that admin users still have convenient access to the dashboard after first landing on the welcome page
  - Added a link to the hfla logo so that anon users are directed to `/` and logged in users are taken to `/welcome`
  - Added a `history.push('/')` to the `logout()` function so that users are redirected to default anon landing page when they logout
  - Moved organization logo to the left side of navbar as requested by stakeholder during live meeting

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://user-images.githubusercontent.com/73561520/228044272-412ba4c5-06b9-41dd-8c6c-212efd124716.png)


</details>

<details>
<summary>Visuals after changes are applied</summary>
  

![image](https://user-images.githubusercontent.com/73561520/228043326-6355786e-67a7-4395-93ea-c30ea5ebb188.png)

</details>
