### PR TITLE
Add project name to dropdown and fix check-in bug

### DIFF
--- a/backend/controllers/event.controller.js
+++ b/backend/controllers/event.controller.js
@@ -6,12 +6,11 @@ EventController.event_list = async function (req, res) {
   const { query } = req;
 
   try {
-    const events = await Event.find(query);
+    const events = await Event.find(query).populate('project');
     return res.status(200).send(events);
   } catch (err) {
     return res.sendStatus(400);
   }
-
 };
 
 EventController.event_by_id = async function (req, res) {
@@ -45,7 +44,6 @@ EventController.destroy = async function (req, res) {
   } catch (err) {
     return res.sendStatus(400);
   }
-  
 };
 
 EventController.update = async function (req, res) {
@@ -58,6 +56,5 @@ EventController.update = async function (req, res) {
     return res.sendStatus(400);
   }
 };
-
 
 module.exports = EventController;

--- a/client/src/pages/CheckInForm.js
+++ b/client/src/pages/CheckInForm.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import moment from 'moment';
 import NewUserForm from './../components/presentational/newUserForm';
 import ReturnUserForm from './../components/presentational/returnUserForm';
-import { REACT_APP_CUSTOM_REQUEST_HEADER as headerToSend} from '../utils/globalSettings';
+import { REACT_APP_CUSTOM_REQUEST_HEADER as headerToSend } from '../utils/globalSettings';
 
 import '../sass/CheckIn.scss';
 
@@ -73,7 +73,6 @@ const CheckInForm = (props) => {
     'Education/STEM',
     'Fundraising',
   ];
-
 
   const fetchQuestions = async () => {
     try {
@@ -200,7 +199,7 @@ const CheckInForm = (props) => {
         })
         .then((response) => {
           const checkInForm = {
-            userId: `${returningUser._id}`,
+            userId: `${returningUser?.user?._id}`,
             eventId: new URLSearchParams(props.location.search).get('eventId'),
           };
 

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -41,10 +41,6 @@ const Home = () => {
     );
   }
 
-  console.log('EVENTS', events);
-
-  console.log('SELECTED EVENT', selectedEvent);
-
   return (
     <div className="home">
       <div className="home-headers">
@@ -92,8 +88,10 @@ const Home = () => {
       )}
 
       <div className="home-buttons">
+        {/* If no events with checkInReady: true */}
         {events.length === 0 && <CreateNewProfileButton />}
 
+        {/* If any events with checkInReady: true */}
         {events.length > 0 && (
           <CheckInButtons
             disabled={selectedEvent === ''}

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -14,6 +14,7 @@ const Home = () => {
     setSelectedEvent(e.currentTarget.value);
   };
 
+  // Fetching only events with checkInReady = true
   useEffect(() => {
     async function fetchEvents() {
       try {
@@ -74,8 +75,7 @@ const Home = () => {
                     {events.map((event) => {
                       return (
                         <option key={event._id || 0} value={event._id}>
-                          {event?.project?.name + ' - ' + event.name ||
-                            '--SELECT ONE--'}
+                          {event?.project?.name + ' - ' + event.name}
                         </option>
                       );
                     })}

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -1,92 +1,109 @@
-import React, { useState, useEffect } from "react";
-import CheckInButtons from "../components/presentational/CheckInButtons";
-import CreateNewProfileButton from "../components/presentational/CreateNewProfileButton";
-import { REACT_APP_CUSTOM_REQUEST_HEADER as headerToSend } from "../utils/globalSettings";
+import React, { useState, useEffect } from 'react';
+import CheckInButtons from '../components/presentational/CheckInButtons';
+import CreateNewProfileButton from '../components/presentational/CreateNewProfileButton';
+import { REACT_APP_CUSTOM_REQUEST_HEADER as headerToSend } from '../utils/globalSettings';
+import { CircularProgress, Box } from '@mui/material';
 
-import "../sass/Home.scss";
+import '../sass/Home.scss';
 
-const Home = (props) => {
-    const [events, setEvents] = useState([]);
-    // eslint-disable-next-line no-unused-vars
-    const [isLoading, setIsLoading] = useState(false);
-    const [event, setEvent] = useState("--SELECT ONE--");
+const Home = () => {
+  const [events, setEvents] = useState(null);
+  const [selectedEvent, setSelectedEvent] = useState('');
 
+  const handleEventChange = (e) => {
+    setSelectedEvent(e.currentTarget.value);
+  };
+
+  useEffect(() => {
     async function fetchEvents() {
-        try {
-            setIsLoading(true);
-            const res = await fetch("/api/events?checkInReady=true", {
-                    headers: {
-                        "x-customrequired-header": headerToSend
-                    }
-                });
-            const resJson = await res.json();
-            await resJson.unshift("--SELECT ONE--");
+      try {
+        const res = await fetch('/api/events?checkInReady=true', {
+          headers: {
+            'x-customrequired-header': headerToSend,
+          },
+        });
+        const resJson = await res.json();
 
-            setEvents(resJson);
-            setIsLoading(false);
-        } catch (error) {
-            console.log(error);
-            setIsLoading(false);
-        }
+        setEvents(resJson);
+      } catch (error) {
+        console.log(error);
+      }
     }
+    fetchEvents();
+  }, []);
 
-    const handleEventChange = (e) => {
-        setEvent(e.currentTarget.value);
-    };
-
-    useEffect(() => {
-        fetchEvents();
-    }, [event]);
-
+  // render loading spinner until API response
+  if (!events) {
     return (
-            <div className="home">
-                <div className="home-headers">
-                    <h1>VRMS</h1>
-                    <h2>Volunteer Relationship Management System</h2>
-                </div>
-
-                {events && events.length > 1 && (
-                    <div className="meeting-select-container">
-                        <form
-                            className="form-select-meeting"
-                            autoComplete="off"
-                            onSubmit={(e) => e.preventDefault()}
-                        >
-                            <div className="form-row">
-                                <div className="form-input-select">
-                                    <label htmlFor={"meeting-checkin"}>
-                                        Select a meeting to check-in:
-                                    </label>
-                                    <div className="radio-buttons">
-                                        <select
-                                            name={"meeting-checkin"}
-                                            className="select-meeting-dropdown"
-                                            onChange={handleEventChange}
-                                            required
-                                        >
-                                            {events.map((event) => {
-                                                return (
-                                                    <option key={event._id || 0} value={event._id}>
-                                                        {event.name || "--SELECT ONE--"}
-                                                    </option>
-                                                );
-                                            })}
-                                        </select>
-                                    </div>
-                                </div>
-                            </div>
-                        </form>
-                    </div>
-                )}
-
-                {events.length > 0 && (
-                    <div className="home-buttons">
-                        {event === "--SELECT ONE--" && events.length === 1 && <CreateNewProfileButton />}
-                        {events.length > 1 && <CheckInButtons disabled={event === "--SELECT ONE--"} event={event} events={events}/>}
-                    </div>
-                )}
-            </div>
+      <Box sx={{ display: 'flex', justifyContent: 'center', mt: 15 }}>
+        <CircularProgress />
+      </Box>
     );
+  }
+
+  console.log('EVENTS', events);
+
+  console.log('SELECTED EVENT', selectedEvent);
+
+  return (
+    <div className="home">
+      <div className="home-headers">
+        <h1>VRMS</h1>
+        <h2>Volunteer Relationship Management System</h2>
+      </div>
+
+      {events && events.length > 1 && (
+        <div className="meeting-select-container">
+          <form
+            className="form-select-meeting"
+            autoComplete="off"
+            onSubmit={(e) => e.preventDefault()}
+          >
+            <div className="form-row">
+              <div className="form-input-select">
+                <label htmlFor={'meeting-checkin'}>
+                  Select a meeting to check-in:
+                </label>
+                <div className="radio-buttons">
+                  <select
+                    name={'meeting-checkin'}
+                    className="select-meeting-dropdown"
+                    onChange={handleEventChange}
+                    required
+                    defaultValue="--SELECT ONE--"
+                  >
+                    <option value="--SELECT ONE--" disabled hidden>
+                      --SELECT ONE--
+                    </option>
+                    {events.map((event) => {
+                      return (
+                        <option key={event._id || 0} value={event._id}>
+                          {event?.project?.name + ' - ' + event.name ||
+                            '--SELECT ONE--'}
+                        </option>
+                      );
+                    })}
+                  </select>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+      )}
+
+      <div className="home-buttons">
+        {events.length === 0 && <CreateNewProfileButton />}
+
+        {events.length > 0 && (
+          <CheckInButtons
+            disabled={selectedEvent === ''}
+            event={selectedEvent}
+            events={events}
+          />
+        )}
+      </div>
+    </div>
+  );
 };
 
 export default Home;


### PR DESCRIPTION
Fixes #1373

### What changes did you make and why did you make them ?
  - Removed unnecessary `isLoading` state from `Home.js` that wasn't actually being used
  - Changed the `--SELECT ONE--` option to be more straightforward instead of doing the ol' `await resJson.unshift("--SELECT ONE--");` 
  - Populated the `project` keys of the `EventController.event_list` so that we have access to project names  via the `GET /api/events/` endpoint
  - Fixed `undefined` **userId** being passed to `POST /api/checkins` endpoint in `CheckInForm.js`

### Screenshots of Proposed Changes Of The Website

- Please note that your dropdown options will not be the same since the meeting check-in feature is set up to only allow checkins to meetings when the time of day is near the meeting start time. In order to manually trigger some events to be `checkInReady` [see comment below](https://github.com/hackforla/VRMS/pull/1375#issuecomment-1497843493)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://user-images.githubusercontent.com/73561520/228346023-e5c30609-f3a4-45e5-b121-fc8488ad84cc.png)

![image](https://user-images.githubusercontent.com/73561520/228618143-a7c9ce52-deca-4b97-9e23-ecf3126ecb62.png)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://user-images.githubusercontent.com/73561520/228620671-57cab094-5620-498f-9c42-efcc8e621802.png)


![image](https://user-images.githubusercontent.com/73561520/228620517-d3da75bc-bc42-4230-8322-8022696b9341.png)


</details>
