### PR TITLE
New Project creation calls to return new proj ID

### DIFF
--- a/client/src/api/ProjectApiService.js
+++ b/client/src/api/ProjectApiService.js
@@ -30,7 +30,9 @@ class ProjectApiService {
     };
 
     try {
-      return await fetch(this.baseProjectUrl, requestOptions);
+      const proj =  await fetch(this.baseProjectUrl, requestOptions);
+      const projectDetails = await proj.json()
+      return projectDetails._id
     } catch (error) {
       console.error(`Add project error: `, error);
       alert('Server not responding.  Please try again.');

--- a/client/src/components/user-admin/AddNewProject.js
+++ b/client/src/components/user-admin/AddNewProject.js
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
 import '../../sass/UserAdmin.scss';
+import { Redirect } from 'react-router-dom';
 
 const AddNewProject = ({
   projects,
   onBackClick,
   handleNewProjectFormSubmit,
+  newlyCreatedProject
 }) => {
   // initialize state hooks
   const [newProjectName, setNewProjectName] = useState(''); // manage input state
@@ -15,6 +17,10 @@ const AddNewProject = ({
   const handleNameChange = (event) => {
     setNewProjectName(event.target.value);
   };
+
+  if (newlyCreatedProject !== null) {
+    return <Redirect to={`/project/${newlyCreatedProject}`} />
+  }
 
   // Handle Form Submit
   const handleProjectFormSubmit = (event) => {
@@ -50,7 +56,7 @@ const AddNewProject = ({
       setAddProjectSuccess(`The project "${newProjectName}" has been added!`);
     }
   };
-
+  
   return (
     <div className="add-new-project">
       <h3>Add New Project</h3>
@@ -62,9 +68,10 @@ const AddNewProject = ({
               placeholder="Project Name"
               value={newProjectName}
               onChange={handleNameChange}
-            />
+              />
             <span className="validation-error">{validationError}</span>
             <span className="project-success">{addProjectSuccess}</span>
+              { newlyCreatedProject && <div>{newlyCreatedProject}</div>}
           </div>
           <br />
           <button className="button-add" type="submit">

--- a/client/src/pages/UserAdmin.js
+++ b/client/src/pages/UserAdmin.js
@@ -22,6 +22,7 @@ const UserAdmin = () => {
   const [projects, setProjects] = useState([]); // All projects pulled from db
   const [userToEdit, setUserToEdit] = useState({}); // The selected user that is being edited
   const [currentPage, setCurrentPage] = useState(PAGES.main);
+  const [newlyCreatedProject, setNewlyCreatedProject] = useState(null);
 
   const [userApiService] = useState(new UserApiService());
   const [projectApiService] = useState(new ProjectApiService());
@@ -46,7 +47,8 @@ const UserAdmin = () => {
 
   const handleNewProjectFormSubmit = useCallback(
     async (projectName) => {
-      await projectApiService.addProjectToDb(projectName);
+      const id = await projectApiService.addProjectToDb(projectName);
+      setNewlyCreatedProject(id)
       fetchProjects();
     },
     [projectApiService, fetchProjects]
@@ -95,6 +97,7 @@ const UserAdmin = () => {
   if (currentPage === PAGES.addNewProject) {
     return (
       <AddNewProject
+        newlyCreatedProject={newlyCreatedProject}
         onBackClick={() => setCurrentPage(PAGES.main)}
         handleNewProjectFormSubmit={handleNewProjectFormSubmit}
         projects={projects}


### PR DESCRIPTION
Fixes #1336 

### What changes did you make and why did you make them ?

  - Modify the fetch request in addProjectToDb to return the new project's ID
  - Save the ID in state in UserAdmin and pass it as props
  - once the ID prop is not null a redirect occurs to the projectID page.


