### PR TITLE
Rename slack 1380

### DIFF
--- a/client/src/components/ProjectForm.js
+++ b/client/src/components/ProjectForm.js
@@ -57,7 +57,7 @@ const simpleInputs = [
     placeholder: 'htttps://github.com/',
   },
   {
-    label: 'Slack Channel URL',
+    label: 'Slack Channel Link',
     name: 'slackUrl',
     type: 'text',
     placeholder: 'htttps://slack.com/',

--- a/client/src/components/manageProjects/editProject.js
+++ b/client/src/components/manageProjects/editProject.js
@@ -115,7 +115,7 @@ const EditProject = ({
         fieldData={projectToEdit.slackUrl}
         fieldName="slackUrl"
         updateProject={updateProject}
-        fieldTitle="Slack URL:"
+        fieldTitle="Slack Channel Link:"
         accessLevel={userAccessLevel}
         canEdit={['admin']}
       />


### PR DESCRIPTION
Fixes #1380

### What changes did you make and why did you make them ?

  - Rename the slack title in the add and edit projects form from 'SlackUrl' to 'Slack Channel Link'

** **Field name was kept as SlackUrl due to how it is stored in MongoDB. This only changes the title users will see.**

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="250" alt="image" src="https://user-images.githubusercontent.com/101952500/232092841-dceda133-8871-45bf-b7c5-dbc9bdc8797b.png">
<img width="250" alt="image" src="https://user-images.githubusercontent.com/101952500/232092949-e74658e0-b168-4742-8aee-cc3196696b99.png">


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="250" alt="image" src="https://user-images.githubusercontent.com/101952500/232091790-7f94885d-52bf-4487-ac53-fefe91d7c7b8.png">
<img width="250" alt="image" src="https://user-images.githubusercontent.com/101952500/232091869-0dd0a09b-3d30-4b3a-997f-2fc647ad0c16.png">


</details>
