### PR TITLE
Resolve fe deploy warnings 1388

### DIFF
--- a/.github/workflows/aws-frontend-deploy.yml
+++ b/.github/workflows/aws-frontend-deploy.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Debug Action
       uses: hmarr/debug-action@v2
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.ref }}
     - name: Set AWS Env & Image Tag per workflow
@@ -45,11 +45,11 @@ jobs:
     needs: [setup_env]
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.ref }}
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v2
       with:
         aws-access-key-id: ${{ secrets.INCUBATOR_AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.INCUBATOR_AWS_SECRET_ACCESS_KEY }}
@@ -80,7 +80,7 @@ jobs:
     needs: [setup_env, build]
     steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v2
       with:
         aws-access-key-id: ${{ secrets.INCUBATOR_AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.INCUBATOR_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Fixes #1388 

### What changes did you make and why did you make them ?
Cleared the below errors by updating the versions:
#### Set-up environment
   - uses: actions/checkout@v3 — updated v2 to v3
#### Build & Push Docker Image:
   - uses: actions/checkout@v3 — updated v2 to v3
   - uses: aws-actions/configure-aws-credentials@v2 — updated v1 to v2
   - satackey/action-docker-layer-caching@v0.0.11 — Already @ latest v.
#### Deploy to AWS ECS
   - aws-actions/configure-aws-credentials@v2
 
****Was not able to resolve the below. Open to any suggestions.**
![image](https://github.com/hackforla/VRMS/assets/101952500/5cffb0a5-2614-44cf-84d0-45bc6cfbb538)


#### Resources 
[set-output and save-state Documentation](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
[Build and Push Docker - v2 to v3](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions)
[Docker Layer version](https://github.com/marketplace/actions/docker-layer-caching)
