### PR TITLE
asset: Add react-hook-form to VRMS client/package.json

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -23,6 +23,7 @@
     "react": "^16.13.1",
     "react-datepicker": "^3.1.3",
     "react-dom": "^16.13.1",
+    "react-hook-form": "^7.44.3",
     "react-router-dom": "^5.1.2",
     "react-scripts": "^3.4.1",
     "validator": "^13.7.0"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -10526,6 +10526,11 @@ react-error-overlay@^6.0.7:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
+react-hook-form@^7.44.3:
+  version "7.44.3"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.44.3.tgz#a99e560c6ef2b668db1daaebc4f98267331b6828"
+  integrity sha512-/tHId6p2ViAka1wECMw8FEPn/oz/w226zehHrJyQ1oIzCBNMIJCaj6ZkQcv+MjDxYh9MWR7RQic7Qqwe4a5nkw==
+
 react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.4, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
Fixes #1406

### What changes did you make and why did you make them ?
This is a small part of @bkmorgan3 's work on #1400, we just need react-hook-form in earlier so we can take on other validation tickets.
* Add `react-hook-form` to package.json, yarn.lock
