### PR TITLE
fix: Update openCheckins to use env var

### DIFF
--- a/backend/workers/closeCheckins.js
+++ b/backend/workers/closeCheckins.js
@@ -3,7 +3,7 @@ module.exports = (cron, fetch) => {
     // Check to see if any events are about to start,
     // and if so, open their respective check-ins
 
-    const url = process.env.NODE_ENV === 'prod' ? 'https://www.vrms.io' : 'http://localhost:4000';
+    const url = process.env.NODE_ENV === 'prod' ? 'https://www.vrms.io' : `http://localhost:${process.env.BACKEND_PORT}`;
     const headerToSend = process.env.CUSTOM_REQUEST_HEADER;
 
     async function fetchEvents() {

--- a/backend/workers/createRecurringEvents.js
+++ b/backend/workers/createRecurringEvents.js
@@ -8,7 +8,7 @@ module.exports = (cron, fetch) => {
     let RECURRING_EVENTS;
     let TODAY_DATE;
     let TODAY;
-    const URL = process.env.NODE_ENV === 'prod' ? 'https://www.vrms.io' : 'http://localhost:4000';
+    const URL = process.env.NODE_ENV === 'prod' ? 'https://www.vrms.io' : `http://localhost:${process.env.BACKEND_PORT}`;
 
     const headerToSend = process.env.CUSTOM_REQUEST_HEADER;
     const fetchEvents = async () => {

--- a/backend/workers/openCheckins.js
+++ b/backend/workers/openCheckins.js
@@ -3,7 +3,7 @@ module.exports = (cron, fetch) => {
     // Check to see if any events are about to start,
     // and if so, open their respective check-ins
 
-    const url = process.env.NODE_ENV === 'prod' ? 'https://www.vrms.io' : 'http://localhost:4000';
+    const url = process.env.NODE_ENV === 'prod' ? 'https://www.vrms.io' : `http://localhost:${process.env.BACKEND_PORT}`;
     const headerToSend = process.env.CUSTOM_REQUEST_HEADER;
 
     async function fetchEvents() {

--- a/backend/workers/slackbot.js
+++ b/backend/workers/slackbot.js
@@ -9,7 +9,7 @@ module.exports = (fetch) => {
 
   const fetchEvents = async () => {
     try {
-      const res = await fetch('http://localhost:4000/api/events', {
+      const res = await fetch(`http://localhost:${process.env.BACKEND_PORT}/api/events`, {
         headers: {
           'x-customrequired-header': headerToSend,
         },


### PR DESCRIPTION
# Was using hardcoded localhost 4000, now uses env var

Fixes #1419

### What changes did you make and why did you make them ?
Single line change, change
```js
# from 
const url = process.env.NODE_ENV === 'prod' ? 'https://www.vrms.io' : 'http://localhost:4000';
# to
const url = process.env.NODE_ENV === 'prod' ? 'https://www.vrms.io' : `http://localhost:${process.env.BACKEND_PORT}`;
```
- This change allows devs to designate other ports for their own development environment (I had mine on 4001 and was wondering why it was failing)
