### PR TITLE
fix: Update Kanban board project name in GH Action

### DIFF
--- a/.github/workflows/New-issue-create-card.yml
+++ b/.github/workflows/New-issue-create-card.yml
@@ -9,5 +9,5 @@ jobs:
       - name: Create or Update Project Card
         uses: peter-evans/create-or-update-project-card@v2
         with:
-          project-name: VRMS v0.4
+          project-name: VRMS - Active Project Board
           column-name: New Issue Approval


### PR DESCRIPTION
Fixes #1421

### What changes did you make and why did you make them ?

  - Change workflow project name from `VRMS v0.4` to current name `VRMS - Active Project Board`
  - Change made because new issues workflow is failing
