### PR TITLE
fix: Add query to return events within 3 weeks

### DIFF
--- a/client/src/api/EventsApiService.js
+++ b/client/src/api/EventsApiService.js
@@ -11,7 +11,13 @@ class EventsApiService {
 
   async fetchEvents() {
     try {
-      const res = await fetch(this.baseUrl, {
+      const threeWeeksInMilliseconds = 3 * 7 * 24 * 60 * 60 * 1000; // 3 weeks in milliseconds
+      const threeWeeksAgo = new Date()
+      threeWeeksAgo.setTime(threeWeeksAgo.getTime() - threeWeeksInMilliseconds)
+      
+      const dateQuery = `?date[$gt]=${threeWeeksAgo.toISOString().split('.')[0]+"Z"}`;
+
+      const res = await fetch(this.baseUrl + dateQuery, {
         headers: this.headers,
       });
       return await res.json();

--- a/client/src/api/EventsApiService.js
+++ b/client/src/api/EventsApiService.js
@@ -12,8 +12,8 @@ class EventsApiService {
   async fetchEvents() {
     try {
       const threeWeeksInMilliseconds = 3 * 7 * 24 * 60 * 60 * 1000; // 3 weeks in milliseconds
-      const threeWeeksAgo = new Date()
-      threeWeeksAgo.setTime(threeWeeksAgo.getTime() - threeWeeksInMilliseconds)
+      const threeWeeksAgo = new Date();
+      threeWeeksAgo.setTime(threeWeeksAgo.getTime() - threeWeeksInMilliseconds);
       
       const dateQuery = `?date[$gt]=${threeWeeksAgo.toISOString().split('.')[0]+"Z"}`;
 


### PR DESCRIPTION
Fixes #1453

### What changes did you make and why did you make them ?
The PR I made to force checkInReady pulls all the events from the db, taking a long time and leading the app to stall. It will eventually return the query populated with data but it's too slow to fit the purpose.

Adding a query string that mongodb recognizes should fix the issue.

  - Add query string to return only events that started within the past 3 weeks


### Screenshots of Proposed Changes Of The Website.
<details>
<summary>Visuals side by side</summary>

 * RIght is previous, left is with changes, returns much less events.
<img width="995" alt="image" src="https://github.com/hackforla/VRMS/assets/5898009/22c4f23f-e7e2-4616-b2b8-01e817d3f05a">

</details>