### PR TITLE
fix: add back project fields hfla website url and  github identifier

### DIFF
--- a/client/src/components/manageProjects/addProject.js
+++ b/client/src/components/manageProjects/addProject.js
@@ -26,13 +26,12 @@ function addProject() {
       addressValue: '',
       addressError: 'Invalid address',
     },
-    // Leaving incase we want to add this back in for updating projects
-    // {
-    //   label: 'GitHub Identifier',
-    //   name: 'githubIdentifier',
-    //   type: 'text',
-    //   placeholder: 'Enter GitHub identifier',
-    // },
+    {
+      label: 'GitHub Identifier',
+      name: 'githubIdentifier',
+      type: 'text',
+      placeholder: 'Enter GitHub identifier',
+    },
     {
       label: 'GitHub URL',
       name: 'githubUrl',
@@ -51,13 +50,12 @@ function addProject() {
       type: 'text',
       placeholder: 'htttps://drive.google.com/',
     },
-    // Leaving incase we want to add this back in for updating projects
-    // {
-    //   label: 'HFLA Website URL',
-    //   name: 'hflaWebsiteUrl',
-    //   type: 'text',
-    //   placeholder: 'htttps://hackforla.org/projects/',
-    // },
+    {
+      label: 'HFLA Website URL',
+      name: 'hflaWebsiteUrl',
+      type: 'text',
+      placeholder: 'htttps://hackforla.org/projects/',
+    },
   ];
 
   return (

--- a/client/src/components/manageProjects/editProject.js
+++ b/client/src/components/manageProjects/editProject.js
@@ -77,13 +77,12 @@ const EditProject = ({
       addressValue: '',
       addressError: 'Invalid address',
     },
-    // Leaving incase we want to add this back in for updating projects
-    // {
-    //   label: 'GitHub Identifier',
-    //   name: 'githubIdentifier',
-    //   type: 'text',
-    //   placeholder: 'Enter GitHub identifier',
-    // },
+    {
+      label: 'GitHub Identifier',
+      name: 'githubIdentifier',
+      type: 'text',
+      placeholder: 'Enter GitHub identifier',
+    },
     {
       label: 'GitHub URL',
       name: 'githubUrl',
@@ -102,13 +101,12 @@ const EditProject = ({
       type: 'text',
       value: projectToEdit.googleDriveUrl,
     },
-    // Leaving incase we want to add this back in for updating projects
-    // {
-    //   label: 'HFLA Website URL',
-    //   name: 'hflaWebsiteUrl',
-    //   type: 'text',
-    //   value: projectToEdit.hflaWebsiteUrl,
-    // },
+    {
+      label: 'HFLA Website URL',
+      name: 'hflaWebsiteUrl',
+      type: 'text',
+      value: projectToEdit.hflaWebsiteUrl,
+    },
   ];
 
   // Get project recurring events when component loads


### PR DESCRIPTION
Fixes an issue that bonnie had with fields missing..

I just commented code back in

<details>
<summary>Visuals before changes are applied</summary>

<img width="554" alt="Screen Shot 2023-08-28 at 8 33 46 PM" src="https://github.com/hackforla/VRMS/assets/53061723/efb507c4-3e6f-41aa-afcc-dddefd09a546">


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="640" alt="Screen Shot 2023-08-28 at 8 32 36 PM" src="https://github.com/hackforla/VRMS/assets/53061723/86b28541-a221-476d-aee8-3c4e44be0dae">


</details>
