### PR TITLE
Normalize left side spacing on TextField MUI component 

### DIFF
--- a/client/src/theme/index.js
+++ b/client/src/theme/index.js
@@ -48,7 +48,7 @@ let theme = createTheme({
     MuiTextField: {
       defaultProps: {
         inputProps: {
-          style: { width: '100%', color: uiKitColors.black, border: 'none' },
+          style: { width: '100%', color: uiKitColors.black, border: 'none', paddingLeft: '0.5em' },
         },
         fullWidth: true,
       },


### PR DESCRIPTION
Fixes #1476

### What changes did you make and why did you make them ?

  - Added `paddingLeft: 0.5em` as a default for `MuiTextField`
  - Addition made to make spacing on the left uniform

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/hackforla/VRMS/assets/65173070/e17ea8f3-d7c8-450b-9468-3dd470649b7b)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/hackforla/VRMS/assets/65173070/eabe5e58-612d-4565-a7df-e552a5cb2b31)

</details>

