### PR TITLE
trim values before accessing DB

### DIFF
--- a/backend/models/project.model.js
+++ b/backend/models/project.model.js
@@ -16,19 +16,19 @@ Idea for the future: programmingLanguages, numberGithubContributions (pull these
 */
 
 const projectSchema = mongoose.Schema({
-    name: { type: String },
-    description: { type: String },
-    githubIdentifier: { type: String },
+    name: { type: String, trim: true },
+    description: { type: String, trim: true },
+    githubIdentifier: { type: String, trim: true },
     projectStatus: { type: String },                    // Active, Completed, or Paused
-    location: { type: String },                         // DTLA, Westside, South LA, or Remote (hacknight)
+    location: { type: String, trim: true },                         // DTLA, Westside, South LA, or Remote (hacknight)
     //teamMembers: { type: String },                    // commented since we should be able to get this from Project Team Members table
     createdDate: { type: Date, default: Date.now },     // date/time project was created
     completedDate: { type: Date },                      // only if Status = Completed, date/time completed
-    githubUrl: { type: String },                        // link to main repo
-    slackUrl: { type: String },                         // link to Slack channel
-    googleDriveUrl: { type: String },
+    githubUrl: { type: String, trim: true },                        // link to main repo
+    slackUrl: { type: String, trim: true },                         // link to Slack channel
+    googleDriveUrl: { type: String, trim: true },
     googleDriveId: { type: String },
-    hflaWebsiteUrl: { type: String },
+    hflaWebsiteUrl: { type: String, trim: true },
     videoConferenceLink: { type: String },
     lookingDescription: { type: String },               // narrative on what the project is looking for
     recruitingCategories: [{ type: String }],           // same as global Skills picklist


### PR DESCRIPTION
Fixes #1402 

### What changes did you make and why did you make them ?

  - On the Project Model for each input that correlates to a Project Field on the add / edit form I added a trim property to remove extra white space on both ends of the value.
  - Added to the Model because if a user bypasses the UI through Postman or something, the values are still trimmed and it places the burden of doing the work on the DB - as light as an operation as it is.
  -

No Screenshots but you confirm this works by Adding and Editing a project with spaces and checking the project in Mongo Compass.
