### PR TITLE
feat: Add missing fields to add/edit form

### DIFF
--- a/client/src/api/ProjectApiService.js
+++ b/client/src/api/ProjectApiService.js
@@ -31,6 +31,8 @@ class ProjectApiService {
       githubUrl,
       slackUrl,
       googleDriveUrl,
+      hflaWebsiteUrl,
+      githubIdentifier,
     } = projectData;
     const requestOptions = {
       method: 'POST',
@@ -42,6 +44,8 @@ class ProjectApiService {
         githubUrl,
         slackUrl,
         googleDriveUrl,
+        hflaWebsiteUrl,
+        githubIdentifier,
         projectStatus: 'Active',
       }),
     };

--- a/client/src/components/manageProjects/editProject.js
+++ b/client/src/components/manageProjects/editProject.js
@@ -25,11 +25,11 @@ const EditProject = ({
     name: projectToEdit.name,
     description: projectToEdit.description,
     location: projectToEdit.location,
-    // githubIdentifier: projectToEdit.name,
+    githubIdentifier: projectToEdit.githubIdentifier,
     githubUrl: projectToEdit.githubUrl,
     slackUrl: projectToEdit.slackUrl,
     googleDriveUrl: projectToEdit.googleDriveUrl,
-    // hflaWebsiteUrl: projectToEdit.name,
+    hflaWebsiteUrl: projectToEdit.hflaWebsiteUrl,
   });
 
   // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
Fixes #1501 

### What changes did you make and why did you make them ?
the fields from the project model `hflaWebsiteUrl`, `githubIdentifier` were not being added to a project on creation and on edit. The fields accepted data but didn't store the data in the db.
  - Updated ProjcetApiService to include hflaWebsiteUrl, githubIdentifier in the db call
  - Updated EditProject to incldue hflaWebsiteUrl, githubIdentifier in the initial set state