### PR TITLE
feat: Whitelist 'onboarding' in event validation

### DIFF
--- a/client/src/components/manageProjects/utilities/validateEventForm.js
+++ b/client/src/components/manageProjects/utilities/validateEventForm.js
@@ -1,5 +1,6 @@
 import validator from 'validator';
 import { isWordInArrayInString } from './../../../utils/stringUtils.js';
+import { el } from 'date-fns/locale';
 
 const validateEventForm = (vals, projectToEdit) => {
   let newErrors = {};
@@ -25,10 +26,14 @@ const validateEventForm = (vals, projectToEdit) => {
             vals[key].toLowerCase()
           )
         ) {
-          newErrors = {
-            ...newErrors,
-            name: `Event name cannot contain the Project Name: '${projectToEdit.name}'`,
-          };
+          if (projectToEdit.name.toLowerCase() === 'onboarding') {
+            // Do nothing, word `onboarding` has been white-listed
+          } else {
+            newErrors = {
+              ...newErrors,
+              name: `Event name cannot contain the Project Name: '${projectToEdit.name}'`,
+            };
+          }
         }
         break;
 


### PR DESCRIPTION
Fixes #1503 

## Please approve this PR but do not merge it
See issue #1503 for details

### What changes did you make and why did you make them ?
  - Update `name` case to not create validation errors when `project name` is onboarding and `onboarding` is in meeting name.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/hackforla/VRMS/assets/5898009/a5c74a25-51c6-4573-b606-9e71dde1ca75)

</details>

<details>
<summary>Visuals after changes are applied</summary>
<img width="475" alt="image" src="https://github.com/hackforla/VRMS/assets/5898009/e9ecbdc0-ae0a-42dc-9d9d-8125939d599a">
</details>
