### PR TITLE
feat: Creat waiting-to-merge action

### DIFF
--- a/.github/workflows/waiting-to-merge.yaml
+++ b/.github/workflows/waiting-to-merge.yaml
@@ -1,0 +1,17 @@
+name: Waiting to Merge
+
+on:
+  pull_request:
+    types: [synchronize, opened, reopened, labeled, unlabeled]
+
+jobs:
+  do-not-merge:
+    if: ${{ contains(github.event.*.labels.*.name, 'waiting to merge') }}
+    name: Prevent Merging
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for label
+        run: |
+          echo "Pull request is labeled as 'waiting to merge'"
+          echo "This workflow fails so that the pull request cannot be merged"
+          exit 1


### PR DESCRIPTION
Prevents merging when a `waiting to merge` label is applied

Fixes #1505 

### What changes did you make and why did you make them ?
- Prevents merging of a PR if `waiting to merge` label is applied
- Still needs to be tested once merged
