### PR TITLE
Ts.1411

### DIFF
--- a/backend/workers/createRecurringEvents.js
+++ b/backend/workers/createRecurringEvents.js
@@ -60,50 +60,56 @@ module.exports = (cron, fetch) => {
             // forEach function with async/await.
             for (filteredEvent of filteredEvents) {
                 const eventExists = await checkIfEventExists(filteredEvent.name);
-                // console.log('Event exists? ', eventExists);
-                const eventDate = new Date(filteredEvent.date);
 
                 if (eventExists) {
+                    //Do nothing
                     console.log("Not going to run ceateEvent");
                 } else {
                     // Create new event
-                    const hours = eventDate.getHours();
-                    const minutes = eventDate.getMinutes();
-                    const seconds = eventDate.getSeconds();
-                    const milliseconds = eventDate.getMilliseconds();
-
-                    const yearToday = TODAY_DATE.getFullYear();
-                    const monthToday = TODAY_DATE.getMonth();
-                    const dateToday = TODAY_DATE.getDate();
-
-                    const newEventDate = new Date(yearToday, monthToday, dateToday, hours, minutes, seconds, milliseconds);
-
-                    const newEndTime = new Date(yearToday, monthToday, dateToday, hours + filteredEvent.hours, minutes, seconds, milliseconds)
-
-                    const eventToCreate = {
-                        name: filteredEvent.name && filteredEvent.name,
-                        hacknight: filteredEvent.hacknight && filteredEvent.hacknight,
-                        eventType: filteredEvent.eventType && filteredEvent.eventType,
-                        description: filteredEvent.eventDescription && filteredEvent.eventDescription,
-                        project: filteredEvent.project && filteredEvent.project,
-                        date: filteredEvent.date && newEventDate,
-                        startTime: filteredEvent.startTime && newEventDate,
-                        endTime: filteredEvent.endTime && newEndTime,
-                        hours: filteredEvent.hours && filteredEvent.hours
-                    }
-                    if (filteredEvent.hasOwnProperty("location")) {
-                        eventToCreate.location = {
-                            city: filteredEvent.location.city ? filteredEvent.location.city : 'REMOTE',
-                            state: filteredEvent.location.state ? filteredEvent.location.state : 'REMOTE',
-                            country: filteredEvent.location.country ? filteredEvent.location.country : 'REMOTE'
-                        };
-                    }
-
+                    const eventToCreate = generateEventData(filteredEvent);
+                    
                     const created = await createEvent(eventToCreate);
                     console.log(created);
                 };
             };
         };
+    };
+
+    function generateEventData(eventData, TODAY_DATE = new Date()) {
+        const eventDate = new Date(eventData.startTime);
+        // Create new event
+        const hours = eventDate.getHours();
+        const minutes = eventDate.getMinutes();
+        const seconds = eventDate.getSeconds();
+        const milliseconds = eventDate.getMilliseconds();
+
+        const yearToday = TODAY_DATE.getFullYear();
+        const monthToday = TODAY_DATE.getMonth();
+        const dateToday = TODAY_DATE.getDate();
+
+        const newEventDate = new Date(yearToday, monthToday, dateToday, hours, minutes, seconds, milliseconds);
+
+        const newEndTime = new Date(yearToday, monthToday, dateToday, hours + filteredEvent.hours, minutes, seconds, milliseconds)
+
+        const eventToCreate = {
+            name: eventData.name && eventData.name,
+            hacknight: eventData.hacknight && eventData.hacknight,
+            eventType: eventData.eventType && eventData.eventType,
+            description: eventData.eventDescription && eventData.eventDescription,
+            project: eventData.project && eventData.project,
+            date: eventData.date && newEventDate,
+            startTime: eventData.startTime && newEventDate,
+            endTime: eventData.endTime && newEndTime,
+            hours: eventData.hours && eventData.hours
+        }
+        if (eventData.hasOwnProperty("location")) {
+            eventToCreate.location = {
+                city: eventData.location.city ? eventData.location.city : 'REMOTE',
+                state: eventData.location.state ? eventData.location.state : 'REMOTE',
+                country: eventData.location.country ? eventData.location.country : 'REMOTE'
+            };
+        }
+        return eventToCreate
     };
 
     async function checkIfEventExists(eventName) {

--- a/backend/workers/createRecurringEvents.js
+++ b/backend/workers/createRecurringEvents.js
@@ -63,13 +63,13 @@ module.exports = (cron, fetch) => {
 
                 if (eventExists) {
                     //Do nothing
-                    console.log("Not going to run ceateEvent");
+                    console.log("➖ Not going to run ceateEvent");
                 } else {
                     // Create new event
                     const eventToCreate = generateEventData(filteredEvent);
                     
                     const created = await createEvent(eventToCreate);
-                    console.log(created);
+                    console.log("➕", created);
                 };
             };
         };


### PR DESCRIPTION
Fixes #1411

### What changes did you make and why did you make them ?
  - Shift code from if/then block to helper function
  - Switch event.date to event.startTime

The bug we were experiencing was because events were being based off of the `event.date` property rather than the `event.startTime` property. When the `createAndFilterEvents` worker ran, it was using old data that the user wasn't setting within the app.

There are already helper functions made on the front end to transfer a timestamp from `6:00 PM` to a valid Date object. The recurring events model has these saved in theory at the right spots, but it is also recommended that project managers update their start times of their events within the app.

If they wish to keep their start times, please update them twice eg `7:00 PM` to `6:00 PM` and back to `7:00 PM`. This way we can ensure that the correct startTime is saved in the `db`.