### PR TITLE
fix: Handle event.date being undefined in closeCheckins

### DIFF
--- a/backend/workers/closeCheckins.js
+++ b/backend/workers/closeCheckins.js
@@ -28,6 +28,12 @@ module.exports = (cron, fetch) => {
         if (events && events.length > 0) {
 
             const sortedEvents = events.filter(event => {
+                if (!event.date) {
+                    // handle if event date is null/undefined
+                    // false meaning don't include in sortedEvents
+                    return false
+                }
+
                 const currentTimeISO = new Date().toISOString();
                 const threeHoursFromStartTime = new Date(event.date).getTime() + 10800000;
                 const threeHoursISO = new Date(threeHoursFromStartTime).toISOString();


### PR DESCRIPTION
Fixes #1540

### What changes did you make and why did you make them ?
  - Add `if` block to check if `.date` prop exists on events object