### PR TITLE
Removed `mvp04` references from`CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,14 +114,12 @@ Note: Understanding how git remotes work will make collaborating much easier. Yo
 
    - `cd vrms/` and run `yarn install`
    - `cd client` and run `yarn install`
-   - `cd client-mvp-04` and run `yarn install`
    - `cd ../backend` and run `yarn install`
 
 1. Add your required environment variables for the frontend and backend directories:
 
    - `touch vrms/backend/.env`
    - `touch vrms/client/.env`
-   - `touch vrms/client-mvp-04/.env`
 
    Note 1: In the above example you are trying to create an empty file called `.env` in each of the listed directories: backend, client and client-mvp-04. You can use either `touch <path-to-directory> .env` or navigate to the directory and use `touch .env`
 


### PR DESCRIPTION
Fixes #1558 

### What changes did you make and why did you make them ?

  - Removed the references of `mvp04` file from the `CONTRIBUTIN.md` 
  - The changes are made by removing the mentions of installing and adding variable environment of `mvp04` during the project local set-up instruction
  - Changes are done as the project is no longer using `MVP-04`

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
- NO VISUAL CHANGES MADE

### Resources
- Changes made are local to the branch and can be seen here: https://github.com/freaky4wrld/VRMS/blob/updating-wiki-removing-mvp04-references-1558/CONTRIBUTING.md#23-get-up-and-running