### PR TITLE
ASSET: Deleted the instances of `MVP-04` references from the Contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,14 +114,12 @@ Note: Understanding how git remotes work will make collaborating much easier. Yo
 
    - `cd vrms/` and run `yarn install`
    - `cd client` and run `yarn install`
-   - `cd client-mvp-04` and run `yarn install`
    - `cd ../backend` and run `yarn install`
 
 1. Add your required environment variables for the frontend and backend directories:
 
    - `touch vrms/backend/.env`
    - `touch vrms/client/.env`
-   - `touch vrms/client-mvp-04/.env`
 
    Note 1: In the above example you are trying to create an empty file called `.env` in each of the listed directories: backend, client and client-mvp-04. You can use either `touch <path-to-directory> .env` or navigate to the directory and use `touch .env`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ Note: Understanding how git remotes work will make collaborating much easier. Yo
    - `touch vrms/backend/.env`
    - `touch vrms/client/.env`
 
-   Note 1: Note 1: In the above example you are trying to create an empty file called .env in each of the listed directories: backend and client. You can use either touch <path-to-directory> .env or navigate to the directory and use touch .env
+   Note 1: In the above example you are trying to create an empty file called .env in each of the listed directories: backend and client. You can use either touch <path-to-directory> .env or navigate to the directory and use touch .env
 
    Note 2: `touch` is a Unix/Linux or Mac command; It is not available in Windows. In Windows, use a text editor (e.g. Notepad) to create an empty file and save it in each of the locations as `.env` . (If you use Windows Explorer to create the file it will create a file called `.env.txt`, which will not work.)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ Note: Understanding how git remotes work will make collaborating much easier. Yo
    - `touch vrms/backend/.env`
    - `touch vrms/client/.env`
 
-   Note 1: In the above example you are trying to create an empty file called `.env` in each of the listed directories: backend, client and client-mvp-04. You can use either `touch <path-to-directory> .env` or navigate to the directory and use `touch .env`
+   Note 1: Note 1: In the above example you are trying to create an empty file called .env in each of the listed directories: backend and client. You can use either touch <path-to-directory> .env or navigate to the directory and use touch .env
 
    Note 2: `touch` is a Unix/Linux or Mac command; It is not available in Windows. In Windows, use a text editor (e.g. Notepad) to create an empty file and save it in each of the locations as `.env` . (If you use Windows Explorer to create the file it will create a file called `.env.txt`, which will not work.)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ Note: Understanding how git remotes work will make collaborating much easier. Yo
    - `touch vrms/backend/.env`
    - `touch vrms/client/.env`
 
-   Note 1: In the above example you are trying to create an empty file called .env in each of the listed directories: backend and client. You can use either `touch <path-to-directory> .env` or navigate to the directory and use `touch .env`
+   Note 1: In the above example you are trying to create an empty file called `.env` in each of the listed directories: backend and client. You can use either `touch <path-to-directory> .env` or navigate to the directory and use `touch .env`
 
    Note 2: `touch` is a Unix/Linux or Mac command; It is not available in Windows. In Windows, use a text editor (e.g. Notepad) to create an empty file and save it in each of the locations as `.env` . (If you use Windows Explorer to create the file it will create a file called `.env.txt`, which will not work.)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ Note: Understanding how git remotes work will make collaborating much easier. Yo
    - `touch vrms/backend/.env`
    - `touch vrms/client/.env`
 
-   Note 1: In the above example you are trying to create an empty file called .env in each of the listed directories: backend and client. You can use either touch <path-to-directory> .env or navigate to the directory and use touch .env
+   Note 1: In the above example you are trying to create an empty file called .env in each of the listed directories: backend and client. You can use either `touch <path-to-directory> .env` or navigate to the directory and use `touch .env`
 
    Note 2: `touch` is a Unix/Linux or Mac command; It is not available in Windows. In Windows, use a text editor (e.g. Notepad) to create an empty file and save it in each of the locations as `.env` . (If you use Windows Explorer to create the file it will create a file called `.env.txt`, which will not work.)
 


### PR DESCRIPTION
Fixes #1558 

### What changes did you make and why did you make them ?

  - The instances to of `MVP-04` are removed from the instructions point directing to add the required variables for `frontend and backend` and for installing the node packages in `MVP-04` directory
  - This is done as we have terminated `MVP-04` folder from the project file-system and we aren't using it as of the current scenario
  -

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
- No visual changes