### PR TITLE
feat: refactor ValidationTextField to accept required property

### DIFF
--- a/client/src/components/data.js
+++ b/client/src/components/data.js
@@ -61,7 +61,8 @@ export const simpleInputs = [
     name: 'hflaWebsiteUrl',
     type: 'text',
     placeholder: 'htttps://hackforla.org/projects/',
-    disabled: false
+    disabled: false,
+    required: false
   },
 ];
 

--- a/client/src/components/parts/form/ValidatedTextField.js
+++ b/client/src/components/parts/form/ValidatedTextField.js
@@ -24,9 +24,7 @@ function ValidatedTextField({
   locationRadios,
   input,
 }) {
-  const registerObj = {
-    ...register(input.name, {
-    required: `${input.name} is required`,
+  const inputObj = {
     pattern:
       input.name === 'location'
         ? locationType === 'remote'
@@ -39,8 +37,15 @@ function ValidatedTextField({
               message: input.addressError,
             }
         : { value: input.value, message: input.errorMessage },
-    }
-  )}
+  };
+  if ('required' in input && input.required === false) {
+    // if required is set to false, don't add required attribute to object
+  } else {
+    inputObj.required = `${input.name} is required`;
+  }
+  const registerObj = {
+    ...register(input.name, inputObj),
+  }
 
   return (
   <Box sx={{ mb: 1 }} key={input.name}>


### PR DESCRIPTION
Fixes #1581

### What changes did you make and why did you make them ?

  - Add `required: false` to `HFLA Website URL` in `data.js`
  - Refactor out object passed to the `register` function `inputObj`
      - test if `required` property is on `input`
      - if property exists and `false`
          - do nothing
      - else
          - add original text to `required` property

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="208" alt="image" src="https://github.com/hackforla/VRMS/assets/141476732/e0b35f98-0ff5-4ae6-b21e-00698c228f1f">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="205" alt="image" src="https://github.com/hackforla/VRMS/assets/141476732/5475c544-d996-4af4-9379-8b7f0f9ffe94">

</details>
