### PR TITLE
fix: Add required to googleDriveId in data.js

### DIFF
--- a/client/src/components/data.js
+++ b/client/src/components/data.js
@@ -94,7 +94,8 @@ export const additionalInputsForEdit = [
     name: 'googleDriveId',
     type: 'text',
     placeholder: 'htttps://drive.google.com/',
-    disabled: false
+    disabled: false,
+    required: false
   },
   // this feature is commented out as per the PR #1577
   // {


### PR DESCRIPTION
Fixes #1585

### What changes did you make and why did you make them ?

  - Add `required: false` to `Google Drive ID` in `data.js`

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="203" alt="image" src="https://github.com/hackforla/VRMS/assets/141476732/311cadbb-9642-4d1c-a907-5173a3dfe7b0">


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="204" alt="image" src="https://github.com/hackforla/VRMS/assets/141476732/4759c8cc-5f5d-4740-9765-2dd9b3d87c82">

</details>
