### PR TITLE
fix: add required property to googleDriveUrl in data.js

### DIFF
--- a/client/src/components/data.js
+++ b/client/src/components/data.js
@@ -54,7 +54,8 @@ export const simpleInputs = [
     name: 'googleDriveUrl',
     type: 'text',
     placeholder: 'htttps://drive.google.com/',
-    disabled: false
+    disabled: false,
+    required: false
   },
   {
     label: 'HFLA Website URL',


### PR DESCRIPTION
Fixes #1585

### What changes did you make and why did you make them ?

  - add `required: false` to `googleDriveUrl` in `data.js`

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="210" alt="image" src="https://github.com/hackforla/VRMS/assets/141476732/d71b0bfb-1253-4ba6-b682-cd3c1cb96b18">

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="209" alt="image" src="https://github.com/hackforla/VRMS/assets/141476732/3d40f112-24cb-42fb-bd20-68cf88bbe55a">

</details>
