### PR TITLE
feat: Have editMeetingTimes use same funcs as createMeetingTimes

### DIFF
--- a/client/src/components/manageProjects/editMeetingTimes.js
+++ b/client/src/components/manageProjects/editMeetingTimes.js
@@ -41,13 +41,10 @@ const EditMeetingTimes = ({
         };
       }
 
-      //if there is a description or a blank description
-      if (values.description || !values.description) {
-        theUpdatedEvent = {
-          ...theUpdatedEvent,
-          description: values.description,
-        };
-      }
+      theUpdatedEvent = {
+        ...theUpdatedEvent,
+        description: values.description,
+      };
 
       if (values.videoConferenceLink) {
         theUpdatedEvent = {
@@ -63,50 +60,23 @@ const EditMeetingTimes = ({
         updatedDate,
       };
 
-      // If the day has been changed, find the next occurence of the changed day
-      if (values.day) {
-        const date = findNextOccuranceOfDay(values.day);
-        const dateGMT = new Date(date).toISOString();
+      // Find next occurance of Day in the future
+      // Assign new start time and end time
+      const date = findNextOccuranceOfDay(values.day);
+      const startTimeDate = timeConvertFromForm(date, values.startTime);
+      const endTime = addDurationToTime(startTimeDate, values.duration);
 
-        theUpdatedEvent = {
-          ...theUpdatedEvent,
-          date: dateGMT,
-        };
-      }
-
-      // Set start time, End time and Duration if either start time or duration is changed
-      if (values.startTime || values.duration) {
-        /*
-        We need a start time and a duration to calculate everything we need.  
-        If only the start time or only the duration is changing, 
-        we use the previous time or duration for the calculation.
-        */
-
-        let startTimeToUse = startTimeOriginal;
-        let durationToUse = durationOriginal;
-
-        if (values.startTime) {
-          startTimeToUse = values.startTime;
-        }
-
-        if (values.duration) {
-          durationToUse = values.duration;
-        }
-
-        const timeDate = timeConvertFromForm(new Date(), startTimeToUse);
-        const endTime = addDurationToTime(timeDate, durationToUse);
-
-        // convert to ISO and GMT
-        const startTimeGMT = new Date(timeDate).toISOString();
-        const endTimeGMT = new Date(endTime).toISOString();
-
-        theUpdatedEvent = {
-          ...theUpdatedEvent,
-          startTime: startTimeGMT,
-          endTime: endTimeGMT,
-          hours: durationToUse,
-        };
-      }
+      // Revert timestamps to GMT
+      const startDateTimeGMT = new Date(startTimeDate).toISOString();
+      const endTimeGMT = new Date(endTime).toISOString();
+        
+      theUpdatedEvent = {
+        ...theUpdatedEvent,
+        date: startDateTimeGMT,
+        startTime: startDateTimeGMT,
+        endTime: endTimeGMT,
+        duration: values.duration
+      };
 
       updateRecurringEvent(theUpdatedEvent, eventID);
       showSnackbar("Recurring event updated", 'info')


### PR DESCRIPTION
Fixes #1591

### What changes did you make and why did you make them ?
  - the update function in prod/dev creates a new `date` timestamp and assigns it to `date` on edit, messing up timing
  - Helper functions for createMeetingTimes generate clean date timetamps
  - Use helper functions from createMeetingTimes to generate the right timing for event check in

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

## Before dev.vrms.io update -- See `raw.date` **is** a clean time stamp with 00:00

<img width="506" alt="image" src="https://github.com/hackforla/VRMS/assets/5898009/795cb44a-15bf-48f8-a933-5cfff7299ab6">

## After dev.vrms.io update --  See `raw.date` **is not** a clean time stamp with 00:00

<img width="506" alt="image" src="https://github.com/hackforla/VRMS/assets/5898009/5289cb26-05ef-4691-acac-becba481fc88">

</details>

<details>
<summary>Visuals after changes are applied</summary>

## After a re-update from new branch See `raw.date` **is again** a clean time stamp with 00:00

<img width="506" alt="image" src="https://github.com/hackforla/VRMS/assets/5898009/60932280-d2ff-42e3-bf06-61e97a389611">

</details>
