### PR TITLE
Remove ability for PMs to edit Project Information on VRMS

### DIFF
--- a/client/src/components/ProjectForm.js
+++ b/client/src/components/ProjectForm.js
@@ -64,7 +64,7 @@ export default function ProjectForm({
   formData,
   projectToEdit,
   isEdit,
-  setFormData
+  setFormData,
 }) {
   const history = useHistory();
 
@@ -74,11 +74,11 @@ export default function ProjectForm({
   const [editMode, setEditMode] = useState(false);
   const { auth } = useAuth();
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const handleOpen = () => setIsModalOpen(true)
-  const handleClose = () => setIsModalOpen(false)
+  const handleOpen = () => setIsModalOpen(true);
+  const handleClose = () => setIsModalOpen(false);
   const checkFields = () => {
-    history.push("/projects")
-  }
+    history.push('/projects');
+  };
 
   /**
    * React Hook Forms
@@ -95,7 +95,7 @@ export default function ProjectForm({
     handleSubmit,
     reset,
     formState: { errors },
-    control
+    control,
   } = useForm({
     mode: 'all',
     // Holds the current project data in state.
@@ -104,7 +104,7 @@ export default function ProjectForm({
     },
   });
 
-  const { dirtyFields } = useFormState({control})
+  const { dirtyFields } = useFormState({ control });
 
   // ----------------- Submit requests -----------------
 
@@ -133,8 +133,6 @@ export default function ProjectForm({
     setFormData(data);
     setEditMode(false);
   };
-
-
 
   // ----------------- Handles and Toggles -----------------
 
@@ -223,52 +221,65 @@ export default function ProjectForm({
       </FormControl>
     </Grid>
   );
+  console.log(
+    'project form component - auth.user.accessLevel: ',
+    auth.user.accessLevel
+  );
+  console.log('project form component - auth.isAdmin: ', auth.isAdmin);
+  /**
+   * user.auth.accessLevel: 'admin'
+   */
 
   return auth && auth.user ? (
     <Box sx={{ px: 0.5 }}>
       <Box sx={{ textAlign: 'center' }}>
         <Typography variant="h1">Project Management</Typography>
       </Box>
-      <TitledBox
-        title={editMode ? 'Editing Project' : 'Project Information'}
-        badge={isEdit ? editIcon() : addIcon()}
-      >
-
-        <form
-          id="project-form"
-          onSubmit={handleSubmit((data) => {
-            isEdit ? submitEditProject(data) : submitNewProject(data);
-          })}
-        >
-
-          {arr.map((input) => (
-            <ValidatedTextField
-              key={input.name}
-              register={register}
-              isEdit={isEdit}
-              editMode={editMode}
-              locationType={locationType}
-              locationRadios={locationRadios}
-              errors={errors}
-              input={input}
-            />
-          ))}
-          <ChangesModal
-        open={isModalOpen}
-        onClose={handleClose}
-        destination={'/projects'}
-        aria-labelledby="modal-modal-title"
-        aria-describedby="modal-modal-description"
-        handleClose={handleClose}
+      {auth.isAdmin ? (
+        <TitledBox
+          title={editMode ? 'Editing Project' : 'Project Information'}
+          badge={isEdit ? editIcon() : addIcon()}
         />
-        </form>
+      ) : (
+        <TitledBox title={'Project Information'} />
+      )}
+      <form
+        id="project-form"
+        onSubmit={handleSubmit((data) => {
+          isEdit ? submitEditProject(data) : submitNewProject(data);
+        })}
+      >
+        {arr.map((input) => (
+          <ValidatedTextField
+            key={input.name}
+            register={register}
+            isEdit={isEdit}
+            editMode={editMode}
+            locationType={locationType}
+            locationRadios={locationRadios}
+            errors={errors}
+            input={input}
+          />
+        ))}
+        <ChangesModal
+          open={isModalOpen}
+          onClose={handleClose}
+          destination={'/projects'}
+          aria-labelledby="modal-modal-title"
+          aria-describedby="modal-modal-description"
+          handleClose={handleClose}
+        />
+      </form>
+      {auth.isAdmin ? (
         <Box>
           <Grid container justifyContent="space-evenly" sx={{ my: 3 }}>
             <Grid item xs="auto">
               <StyledButton
                 type="submit"
                 form="project-form"
-                variant={!isEdit ? 'secondary' : !editMode ? 'contained' : 'secondary'}
+                variant={
+                  !isEdit ? 'secondary' : !editMode ? 'contained' : 'secondary'
+                }
                 cursor="pointer"
                 disabled={isEdit ? !editMode : false}
               >
@@ -279,14 +290,20 @@ export default function ProjectForm({
               <StyledButton
                 variant="contained"
                 cursor="pointer"
-                onClick={!editMode || Object.keys(dirtyFields).length === 0 ? checkFields: handleOpen}
+                onClick={
+                  !editMode || Object.keys(dirtyFields).length === 0
+                    ? checkFields
+                    : handleOpen
+                }
               >
                 Close
               </StyledButton>
             </Grid>
           </Grid>
         </Box>
-      </TitledBox>
+      ) : (
+        ''
+      )}
     </Box>
   ) : (
     <Redirect to="/login" />

--- a/client/src/components/ProjectForm.js
+++ b/client/src/components/ProjectForm.js
@@ -221,14 +221,6 @@ export default function ProjectForm({
       </FormControl>
     </Grid>
   );
-  console.log(
-    'project form component - auth.user.accessLevel: ',
-    auth.user.accessLevel
-  );
-  console.log('project form component - auth.isAdmin: ', auth.isAdmin);
-  /**
-   * user.auth.accessLevel: 'admin'
-   */
 
   return auth && auth.user ? (
     <Box sx={{ px: 0.5 }}>

--- a/client/src/components/ProjectForm.js
+++ b/client/src/components/ProjectForm.js
@@ -235,7 +235,7 @@ export default function ProjectForm({
       <Box sx={{ textAlign: 'center' }}>
         <Typography variant="h1">Project Management</Typography>
       </Box>
-      {auth.isAdmin ? (
+      {auth.user.accessLevel === 'admin' ? (
         <TitledBox
           title={editMode ? 'Editing Project' : 'Project Information'}
           badge={isEdit ? editIcon() : addIcon()}
@@ -270,7 +270,7 @@ export default function ProjectForm({
           handleClose={handleClose}
         />
       </form>
-      {auth.isAdmin ? (
+      {auth.user.accessLevel === 'admin' ? (
         <Box>
           <Grid container justifyContent="space-evenly" sx={{ my: 3 }}>
             <Grid item xs="auto">

--- a/client/src/components/parts/boxes/TitledBox.js
+++ b/client/src/components/parts/boxes/TitledBox.js
@@ -2,27 +2,25 @@ import React from 'react';
 import { Box, Typography, Divider } from '@mui/material';
 
 export default function TitledBox({ title, children, badge, childrenBoxSx }) {
-    return (
-        <Box sx={{ bgcolor: '#F5F5F5', my: 3 }}>
-            <Box
-                sx={{
-                    p: 2,
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'center',
-                }}
-            >
-                <Box>
-                    <Typography sx={{ fontSize: '18px', fontWeight: '600' }}>
-                        {title}
-                    </Typography>
-                </Box>
-                {badge}
-            </Box>
-            <Divider sx={{ borderColor: 'rgba(0,0,0,1)' }} />
-            <Box sx={{ py: 2, px: 4, ...childrenBoxSx }}>{children}</Box>
+  return (
+    <Box sx={{ bgcolor: '#F5F5F5', my: 3 }}>
+      <Box
+        sx={{
+          p: 2,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <Box>
+          <Typography sx={{ fontSize: '18px', fontWeight: '600' }}>
+            {title}
+          </Typography>
         </Box>
-    );
-
-
+        {badge ? badge : ' '}
+      </Box>
+      <Divider sx={{ borderColor: 'rgba(0,0,0,1)' }} />
+      <Box sx={{ py: 2, px: 4, ...childrenBoxSx }}>{children}</Box>
+    </Box>
+  );
 }


### PR DESCRIPTION
Fixes #1630 

### What changes did you make and why did you make them?

  - Conditionally rendering the edit button (badge) on the project form based on whether or not `auth.user.acessLevel === 'admin'`
  - If not the user is not an admin, the user should not have the ability to edit the project information but will be able to add and edit events.
 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="792" alt="Screenshot 2024-05-12 at 17 12 47" src="https://github.com/hackforla/VRMS/assets/103938273/90cd5cd1-94ba-4ec4-a6c8-f21914904089">
<img width="792" alt="Screenshot 2024-05-12 at 17 12 58" src="https://github.com/hackforla/VRMS/assets/103938273/35511d5c-6cb5-4c56-aec2-ef189859eba8">


</details>

<details>
<summary>Visuals after changes are applied</summary>
 
<img width="792" alt="Screenshot 2024-05-12 at 17 16 03" src="https://github.com/hackforla/VRMS/assets/103938273/3e528e55-3794-4862-bdf7-434e088ad88c">
<img width="792" alt="Screenshot 2024-05-12 at 17 16 15" src="https://github.com/hackforla/VRMS/assets/103938273/fa862f51-80c1-4d3b-832c-08a47d513288">
<img width="792" alt="Screenshot 2024-05-12 at 17 16 09" src="https://github.com/hackforla/VRMS/assets/103938273/14ab7502-4457-4043-b909-5bf755bae0b8">

</details>
