### PR TITLE
refactor project filtering for PMs

### DIFF
--- a/backend/controllers/project.controller.js
+++ b/backend/controllers/project.controller.js
@@ -13,6 +13,16 @@ ProjectController.project_list = async function (req, res) {
   }
 };
 
+ProjectController.projects = async function(req, res) {
+  try {
+    const projectList = await Project.find({})
+    const projects = projectList.filter(proj => req.body.includes(proj._id.toString()))
+    return res.status(200).send(projects)
+  } catch(e) {
+    return res.sendStatus(400)
+  }
+}
+
 ProjectController.create = async function (req, res) {
   const { body } = req;
 

--- a/backend/controllers/project.controller.js
+++ b/backend/controllers/project.controller.js
@@ -13,7 +13,7 @@ ProjectController.project_list = async function (req, res) {
   }
 };
 
-ProjectController.projects = async function(req, res) {
+ProjectController.pm_filtered_projects = async function(req, res) {
   try {
     const projectList = await Project.find({})
     const projects = projectList.filter(proj => req.body.includes(proj._id.toString()))

--- a/backend/routers/projects.router.js
+++ b/backend/routers/projects.router.js
@@ -7,6 +7,8 @@ const { AuthUtil } = require("../middleware");
 // The base is /api/projects
 router.get('/', ProjectController.project_list);
 
+router.put('/', ProjectController.projects);
+
 router.post('/', AuthUtil.verifyCookie, ProjectController.create);
 
 router.get('/:ProjectId', ProjectController.project_by_id);

--- a/backend/routers/projects.router.js
+++ b/backend/routers/projects.router.js
@@ -7,7 +7,8 @@ const { AuthUtil } = require("../middleware");
 // The base is /api/projects
 router.get('/', ProjectController.project_list);
 
-router.put('/', ProjectController.projects);
+// Its a put because we have to send the PM projects to be filtered here
+router.put('/', ProjectController.pm_filtered_projects);
 
 router.post('/', AuthUtil.verifyCookie, ProjectController.create);
 

--- a/client/src/api/ProjectApiService.js
+++ b/client/src/api/ProjectApiService.js
@@ -83,6 +83,21 @@ class ProjectApiService {
       return undefined;
     }
   }
+
+  async fetchPMProjects(projects) {
+    const requestOptions = {
+      headers: this.headers,
+      method: "PUT",
+      body: JSON.stringify(projects)
+    }
+    try {
+        const res = await fetch(this.baseProjectUrl, requestOptions);
+        return await res.json();
+    } catch(e) {
+      console.error(e);
+      return undefined;
+    }
+  }
 }
 
 export default ProjectApiService;

--- a/client/src/pages/ProjectList.js
+++ b/client/src/pages/ProjectList.js
@@ -42,21 +42,18 @@ export default function ProjectList() {
   useEffect(
     function getProjectsOnMount() {
       async function fetchAllProjects() {
-        let projectsData = await projectApiService.fetchProjects();
+        let projectData;
 
-        //sort the projects alphabetically
-        projectsData = projectsData.sort((a, b) =>
-          a.name?.localeCompare(b.name)
-        );
+        if(user?.accessLevel === 'admin') {
+          projectData = await projectApiService.fetchProjects();
+          setProjects(projectData);
+        }
 
         // if user is not admin, but is a project manager, only show projects they manage
         if (user?.accessLevel !== 'admin' && user?.managedProjects.length > 0) {
-          projectsData = projectsData.filter((project) =>
-            user.managedProjects.includes(project._id)
-          );
+          projectData = await projectApiService.fetchPMProjects(user.managedProjects);
+          setProjects(projectData);
         }
-
-        setProjects(projectsData);
       }
 
       fetchAllProjects();


### PR DESCRIPTION
Fixes #1619 

### What changes did you make and why did you make them ?

  - refactor logic for fetching projects based on role
  - filter PM projects on the server
  
For Testing you will need an Admin account to fetch all projects and a non-admin PM account with one project and if needed you can push a project into user.managedProjects to see how it works with more than 1 project.

