### PR TITLE
Prevent layout shift admin page

### DIFF
--- a/client/src/components/auth/Auth.js
+++ b/client/src/components/auth/Auth.js
@@ -22,7 +22,7 @@ const Auth = () => {
   const [email, setEmail] = useState('');
   const [isDisabled, setIsDisabled] = useState(true);
   const [isError, setIsError] = useState(false);
-  const [errorMessage, setErrorMessage] = useState('');
+  const [errorMessage, setErrorMessage] = useState(' ');
 
   const validateEmail = () => {
     if (email.search(pattern) !== -1) {
@@ -102,7 +102,11 @@ const Auth = () => {
         <div className="adminlogin-headers">
           <h3>Welcome Back!</h3>
         </div>
-        <form onSubmit={handleLogin} className="form-check-in" autoComplete="off">
+        <form
+          onSubmit={handleLogin}
+          className="form-check-in"
+          autoComplete="off"
+        >
           <div className="form-row">
             <div className="form-input-text">
               <label htmlFor="email">Enter your email address:</label>
@@ -120,7 +124,12 @@ const Auth = () => {
           </div>
         </form>
 
-        {isError && <div className="adminlogin-warning">{errorMessage}</div>}
+        <div
+          className="adminlogin-warning"
+          style={{ visibility: isError ? 'visible' : 'hidden' }}
+        >
+          {errorMessage}
+        </div>
 
         <div className="form-input-button">
           <button

--- a/client/src/sass/AdminLogin.scss
+++ b/client/src/sass/AdminLogin.scss
@@ -1,17 +1,18 @@
 .adminlogin-container {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    z-index: 1;
-    padding-top: 6vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  z-index: 1;
+  padding-top: 6vh;
 }
 
 .adminlogin-headers {
-    margin: 36px 0px;
+  margin: 36px 0px;
 }
 
 .adminlogin-warning {
-    width: 300px;
-    color: red;
+  width: 300px;
+  color: red;
+  height: 20px;
 }


### PR DESCRIPTION
Fixes #1645

### What changes did you make and why did you make them?

  - made changes in auth.js to render error container always, prevent layout shifting
  - set height in the style sheet for  error messages with multi lines


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
