### PR TITLE
Fix: broken link to issue board in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,6 @@
 
 <p>This document outlines the process for joining our team and contributing to the VRMS Github repository. If you notice errors or have important information to add, please feel free to propose changes to this document with a pull request</p>
 
-
 <h2>Table of Contents</h2>
 
 - [**Part 1 : How to join the team**](#part-1--how-to-join-the-team)
@@ -24,15 +23,16 @@
   - [**4.1 Push changes to your forked repository**](#41-push-changes-to-your-forked-repository)
   - [**4.2 Create a pull request on the VRMS repository**](#42-create-a-pull-request-on-the-vrms-repository)
 
-
 ## **Part 1 : How to join the team**
 
 ### **1.1 VRMS contributor expectations**
+
 - Attend at least 1 team meeting per week
 - Devote a minimum of 6 hours per week to working on VRMS assignments
 - Communicate with the team leadership if you plan to step away from the project
 
 ### **1.2 Reach out to us on Slack**
+
 If you would like to contribute to our project, please reach out to the team leads on Slack or at one of our weekly meetings. You can find the current project team, their slack links, and our team meeting times on the [VRMS Project Details Page](https://www.hackforla.org/projects/vrms).
 
 ### **1.3 Become a member of the repository Team**
@@ -50,15 +50,16 @@ These steps are manditory in order to contribute to all HackforLA projects.
 ## **Part 2: How to set up the development environment**
 
 ### **2.1 Fork the repository**
-*A fork is a copy of the repository that will be placed on your GitHub account url.*
 
-* In https://github.com/hackforla/VRMS, look for the fork icon in the top right. Click it and create a fork of the repository. 
+_A fork is a copy of the repository that will be placed on your GitHub account url._
 
-* It should create a copy here: https://github.com/YOUR_GITHUB_USERNAME/vrms, where `YOUR_GITHUB_USERNAME` is replaced with your github username.
+- In https://github.com/hackforla/VRMS, look for the fork icon in the top right. Click it and create a fork of the repository.
+
+- It should create a copy here: https://github.com/YOUR_GITHUB_USERNAME/vrms, where `YOUR_GITHUB_USERNAME` is replaced with your github username.
 
 > NOTE: This copy is on a remote server on the GitHub website and not on your computer yet.
 
-* Click the icon again, it will give you the URL associated with your forked repository and not create a new fork.
+- Click the icon again, it will give you the URL associated with your forked repository and not create a new fork.
 
 ### **2.2 Clone the remote repository to your local computer**
 
@@ -67,39 +68,42 @@ The following process will make a copy of the fork that you just created on your
 1. Create a new folder on your local computer that will contain `hackforla` projects.
 
 2. In your shell (terminal), navigate to this folder then run the following commands:
-	```bash
-	git clone https://github.com/YOUR_GITHUB_USERNAME/vrms.git
-	```
 
-	You should now have a new folder in your `hackforla` folder called `vrms`.
+   ```bash
+   git clone https://github.com/YOUR_GITHUB_USERNAME/vrms.git
+   ```
+
+   You should now have a new folder in your `hackforla` folder called `vrms`.
 
 3. Verify which URL your `origin` remote is pointing to:
-	```bash
-	git remote show origin
-	```
-	Your terminal should return:
-	```bash
-	remote origin
-	Fetch URL: https://github.com/YOUR_GITHUB_USERNAME/vrms.git
-	Push URL: https://github.com/YOUR_GITHUB_USERNAME/vrms.git
-	...
-	```	
 
-	If you accidentally cloned the `hackforla/vrms.git` then you can change your local copy to upload to your fork with the following:
+   ```bash
+   git remote show origin
+   ```
 
-	```bash
-	git remote set-url origin https://github.com/YOUR_GITHUB_USERNAME/vrms.git
-	```
+   Your terminal should return:
+
+   ```bash
+   remote origin
+   Fetch URL: https://github.com/YOUR_GITHUB_USERNAME/vrms.git
+   Push URL: https://github.com/YOUR_GITHUB_USERNAME/vrms.git
+   ...
+   ```
+
+   If you accidentally cloned the `hackforla/vrms.git` then you can change your local copy to upload to your fork with the following:
+
+   ```bash
+   git remote set-url origin https://github.com/YOUR_GITHUB_USERNAME/vrms.git
+   ```
 
 4. Add another remote called `vrms` that points to the `hackforla` version of the repository. This will allow you to incorporate changes later:
-	```bash
-	git remote add vrms https://github.com/hackforla/vrms.git
-	```
+   ```bash
+   git remote add vrms https://github.com/hackforla/vrms.git
+   ```
 
 Note: Understanding how git remotes work will make collaborating much easier. You can learn more about remotes [here](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/configuring-a-remote-for-a-fork) and [here](https://git-scm.com/book/en/v2/Git-Basics-Working-with-Remotes).
 
-
-### **2.3 Get up and running**   
+### **2.3 Get up and running**
 
 1. Have [Node](https://nodejs.org/en/download/) and NPM installed locally:
 
@@ -128,7 +132,7 @@ Note: Understanding how git remotes work will make collaborating much easier. Yo
 
    Note 2: `touch` is a Unix/Linux or Mac command; It is not available in Windows. In Windows, use a text editor (e.g. Notepad) to create an empty file and save it in each of the locations as `.env` . (If you use Windows Explorer to create the file it will create a file called `.env.txt`, which will not work.)
 
-   - Then paste the content from the [document](https://docs.google.com/document/d/1PdcZhyo2a2lr0JNcgyzpWi98tGkZeH1Zxz-Jnf6JQDU/edit?usp=sharing). It is accessible for the project team members only. 
+   - Then paste the content from the [document](https://docs.google.com/document/d/1PdcZhyo2a2lr0JNcgyzpWi98tGkZeH1Zxz-Jnf6JQDU/edit?usp=sharing). It is accessible for the project team members only.
 
    - _Please note that the `ports` for the frontend and backend are set in this location_
 
@@ -140,16 +144,15 @@ Note: Understanding how git remotes work will make collaborating much easier. Yo
 
    - Navigate to the root of the application `vrms/` and run `yarn start`
 
-   *Troubleshooting :* If you encounter the following error after running `yarn start`:
-   
-      ```
-      Error: error:0308010C:digital envelope routines::unsupported
-      ```
+   _Troubleshooting :_ If you encounter the following error after running `yarn start`:
+
+   ```
+   Error: error:0308010C:digital envelope routines::unsupported
+   ```
+
    Try changing your node version to `16.14.2` by running `nvm use 16.14.2`. If you do not have `nvm` installed, see [install instructions](https://github.com/nvm-sh/nvm#installing-and-updating)
 
-
 You should now have a live app. Happy hacking.
-
 
 ### **2.4 Running Tests**
 
@@ -166,66 +169,68 @@ To view and edit the development database manually, you can download [MongoDB Co
 
 If you want to install a local copy to experiment with and learn more about MongoDB, you can use [this tutorial](https://zellwk.com/blog/local-mongodb/)
 
-
-
 ## **Part 3: How to work on issues**
-
 
 ### **3.1 Claim an Issue**
 
-Developers may assign themselves to issues from the [Prioritized Backlog column](https://github.com/hackforla/VRMS/projects/12#column-19074778) of the project board.
+Developers may assign themselves to issues from the [Prioritized Backlog column](https://github.com/orgs/hackforla/projects/72/views/1?filterQuery=backlog) of the project board.
 
 The Prioritized Backlog column is filtered so the first (top) issue has the highest priority and should be worked on next if possible.
 
 Developers may choose from issues with the following `role` labels:
+
 - `role: Front End`
 - `role: Back End`
 - `role: Database`
 
 Claiming an issue is a two step process:
+
 1. Assign yourself to the issue using the gear icon in the upper right corner of the issue where it says "Assignees"
 2. Move the issue from the `Prioritized Backlog` to the `In Progress` column of the project board
 
-
 ### **3.2 Create a new branch for each issue you work on**
+
 You will create a new branch for each issue you work on. Doing all your work on feature branches leaves your repository's main branch unmodified and greatly simplifies keeping your fork in sync with the main project.
 
-
-1. Before creating a new branch, always make sure you are currently on the `development` branch by using the command 
-	```bash
-	git branch
-	```
+1. Before creating a new branch, always make sure you are currently on the `development` branch by using the command
+   ```bash
+   git branch
+   ```
 2. Before creating a new branch, always pull down the latest changes from the `development` branch by using the command
-	```bash
-	git pull vrms development
-	```
+   ```bash
+   git pull vrms development
+   ```
 3. Finally, create a new branch where you will work on your issue by using the command:
-	```bash
-	git checkout -b your-branch-name
-	```
+   ```bash
+   git checkout -b your-branch-name
+   ```
 
 ### **3.3 Work on the Issue**
+
 Every issue will contain action items you must complete before you are ready to submit a pull request. Be sure to use the checkboxes as you complete each action item so we can track your progress!
 
-
 After you have completed the action items, add and commit the changes to your new branch using the commands
+
 ```
 git add .
 git commit -m "your commit message"
-``` 
-
+```
 
 ## **Part 4: How to create pull requests**
+
 ### **4.1 Push changes to your forked repository**
+
 1. Before pushing code, always pull down the latest changes from the `development` branch by using the command
-	```
-	git pull vrms development
-	```
+   ```
+   git pull vrms development
+   ```
 2. Once you are satisfied with your changes, push them to the feature branch you made within your remote repository.
-	```
-	git push --set-upstream origin your-branch-name
-	```
+   ```
+   git push --set-upstream origin your-branch-name
+   ```
+
 ### **4.2 Create a pull request on the VRMS repository**
+
 1. Go to your fork of the VRMS repository on GitHub and click on the `Compare & pull request` button. <details><summary>See screenshot</summary> <img src="https://user-images.githubusercontent.com/73561520/220488394-09bc759e-98d9-4a09-86c6-66378cf50923.png"/></details>
 2. Be sure to title your pull request by summarizing the changes you made
 3. Be sure to add your issue number where the template says `Fixes #replace_this_text_with_the_issue_number`


### PR DESCRIPTION
### What changes did you make and why did you make them ?

  - Changed link to the issue board's `Prioritized Backlog` because current link was taking me to a 404 page.
 #### Note
- If there's a different link that is preferred, let me know and I'll happily switch it out. 

### Screen Captures of Proposed Changes
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Screen Capture before changes are applied</summary>

https://github.com/user-attachments/assets/5ab22374-18d6-46fe-86d0-21d385826ad3


</details>

<details>
<summary>Screen Capture after changes are applied</summary>

https://github.com/user-attachments/assets/2a44ba56-8aa3-4f53-99a6-e883fc495beb

</details>

### Links to test yourself
[Current CONTRIBUTING.md — click on the "Prioritized Backlog Column" link](https://github.com/hackforla/VRMS/blob/development/CONTRIBUTING.md#31-claim-an-issue)
[Fixed CONTRIBUTING.md — click on the "Prioritized Backlog Column" link](https://github.com/pluto-bell/VRMS/blob/fix-broken-issues-link/CONTRIBUTING.md#31-claim-an-issue)
