### PR TITLE
Update HTML components to MUI components for ManageProjects page

### DIFF
--- a/client/src/pages/ManageProjects.jsx
+++ b/client/src/pages/ManageProjects.jsx
@@ -8,12 +8,35 @@ import RecurringEventsApiService from '../api/RecurringEventsApiService';
 import Loading from '../svg/22.gif';
 import '../sass/ManageProjects.scss';
 import EventsApiService_ from '../api/EventsApiService';
+import { Typography, Box } from '@mui/material';
 
 const PAGES = Object.freeze({
   selectProject: 'selectProject',
   editProjectInfo: 'editProjectInfo',
   editMeetingTimes: 'editMeetingTimes',
 });
+
+// Added styles for MUI components
+const loadingStyle = {
+  "display": "none",
+  "position": "absolute",
+  "display": "flex",
+  "flexDirection": "row",
+  "alignItems": "center",
+  "justifyContent": "center",
+  "zIndex": 1,
+  "top": 0,
+  "left": 0,
+  "right": 0,
+  "backgroundColor": "white",
+  "height": '100%',
+  "opacity": 0.6,
+}
+
+const noStyle = {
+  "opacity": 0,
+  "display": "none",
+}
 
 const ManageProjects = () => {
   const { projectId } = useParams();
@@ -155,13 +178,13 @@ const ManageProjects = () => {
   }
   return (
     <>
-      <span
-        className={`bg-overlay ${
-          eventsLoading || projectsLoading ? 'active' : ''
-        }`}
+      <Typography
+        sx={eventsLoading || projectsLoading ? loadingStyle : noStyle}
+        component='span'
+        display='inline'
       >
-        <img src={Loading} alt="Logo" />
-      </span>
+        <Box component='img' src={Loading} alt="Logo" />
+      </Typography>
       {displayedComponent}
     </>
   );

--- a/client/src/pages/ManageProjects.jsx
+++ b/client/src/pages/ManageProjects.jsx
@@ -8,7 +8,7 @@ import RecurringEventsApiService from '../api/RecurringEventsApiService';
 import Loading from '../svg/22.gif';
 import '../sass/ManageProjects.scss';
 import EventsApiService_ from '../api/EventsApiService';
-import { Typography, Box } from '@mui/material';
+import { Box } from '@mui/material';
 
 const PAGES = Object.freeze({
   selectProject: 'selectProject',
@@ -178,13 +178,13 @@ const ManageProjects = () => {
   }
   return (
     <>
-      <Typography
+      <Box
         sx={eventsLoading || projectsLoading ? loadingStyle : noStyle}
         component='span'
         display='inline'
       >
         <Box component='img' src={Loading} alt="Logo" />
-      </Typography>
+      </Box>
       {displayedComponent}
     </>
   );


### PR DESCRIPTION
Fixes #1719 

### What changes did you make and why did you make them ?

  - Replaced HTML `span` tag with MUI `Typography` component
  - Replaced HTML `img` tag with MUI `Box` component
  - Added custom style properties to match original CSS 
  - <b>WHY:</b> To modernize the frontend components

### Screenshots of Proposed Changes Of The Website 
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
<img width="500" alt="1719 before screen" src="https://github.com/user-attachments/assets/c09e1e3b-5b62-4ee7-ad00-04f595a0100a" />
</details>

<details>
<summary>Visuals after changes are applied</summary>
<img width="500" alt="1719 after screen" src="https://github.com/user-attachments/assets/27172f56-0e3b-4032-b809-9e871574727a" />
</details>
