### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,6 +182,8 @@ Developers may choose from issues with the following `role` labels:
 - `role: Front End`
 - `role: Back End`
 - `role: Database`
+- `role: devops`
+- *_Lead developers may choose from the above labels, as well as issues with the label:_ `role: Dev Lead`
 
 Claiming an issue is a two step process:
 


### PR DESCRIPTION
Updated contributing with additional 'role' labels that developers can choose from (e.g., 'role: devops' & 'role: Dev Lead'

### What changes did you make and why did you make them ?

  - Currently the developer 'role' labels listed on the Contributing doc are not up to date, and 2 developer labels are currently missing. Given that, I have added the following labels:
    - 'role: devops'
    - 'role: Dev Lead'

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
