### PR TITLE
fix: Change conditional to show managed projects list in an else block

### DIFF
--- a/client/src/pages/ProjectList.jsx
+++ b/client/src/pages/ProjectList.jsx
@@ -40,12 +40,13 @@ export default function ProjectList({ auth }) {
       async function fetchAllProjects() {
         let projectData;
 
-        if(user?.accessLevel === 'admin' || user?.accessLevel === 'superadmin') {
+        if (
+          user?.accessLevel === 'admin' ||
+          user?.accessLevel === 'superadmin'
+        ) {
           projectData = await projectApiService.fetchProjects();
-        }
-
-        // if user is not admin, but is a project manager, only show projects they manage
-        if ((user?.accessLevel !== 'admin' || user?.accessLevel !== 'superadmin') && user?.managedProjects.length > 0) {
+        } else if (user?.managedProjects?.length > 0) {
+          // if user is not admin, but is a project manager, only show projects they manage
           projectData = await projectApiService.fetchPMProjects(user.managedProjects);
         }
         


### PR DESCRIPTION
Fixes #1958

### What changes did you make and why did you make them ?

- Shift managedProjects condition into and else block
  - This was overwriting projectList if the user was an `admin` and had projects they managed.