### PR TITLE
include instruction for installing NVM in -2.3 Get up and runnig- section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,22 @@ Note: Understanding how git remotes work will make collaborating much easier. Yo
 
 ### **2.3 Get up and running**
 
+1. Install NVM (Node Version Manager). NVM allows you to easily manage and switch between multiple versions of Node.
+
+   - Verify the installation: `nvm --version`
+   - Once NVM is verified, run the following commands from the root of the project:
+
+   ```
+   # Install the project's Node version (specified in the .nvmrc file)
+   nvm install
+
+   # Instruct NVM to use the Node version defined in the .nvmrc file
+   nvm use
+
+   ```
+
+   > NOTE: If the major version of Node does not match the version specified in the .nvmrc file, you may need to be explicit with the version and use: `nvm install <version>` and `nvm use <version>`
+
 1. Have [Node](https://nodejs.org/en/download/) and NPM installed locally:
 
    - Verify with `node -v` and `npm -v` respectively.


### PR DESCRIPTION
Fixes [2027](https://github.com/hackforla/VRMS/issues/2027)

### Reason for Request:
The instructions under section 2.3 “Get up and running” currently ask the user to install the latest version of Node.js; however, the version required by the project is Node v18 (as specified in the .nvmrc file in the root of the project).

### What changes did you make and why did you make them ?

- Before the instruction for checking the existence of Node on the host machine, I added a section for installing NVM (Node Version Manager).
- The instructions guide the developer through installing the correct version of Node (as of this PR, v18), as defined in the .nvmrc file.
- These changes ensure that all new team members use the correct major version of Node for the project.


### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

<img width="1304" height="563" alt="image" src="https://github.com/user-attachments/assets/a3fd14e9-4441-4119-8c62-a06022668a74" />
