### PR TITLE
update github action upload-artifact to V4

### DIFF
--- a/.github/workflows/pr-instructions.yml
+++ b/.github/workflows/pr-instructions.yml
@@ -28,7 +28,7 @@ jobs:
           echo ${{ steps.instruction.outputs.result }} > addingPrInstructions/artifact/artifact.txt
       
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: adding-pr-instructions-artifact
           path: addingPrInstructions/artifact/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ Note: Understanding how git remotes work will make collaborating much easier. Yo
 
 ### **2.3 Get up and running**
 
-1. Install NVM (Node Version Manager). NVM allows you to easily manage and switch between multiple versions of Node.
+1. Install [NVM (Node Version Manager)](https://github.com/nvm-sh/nvm). NVM allows you to easily manage and switch between multiple versions of Node.
 
    - Verify the installation: `nvm --version`
    - Once NVM is verified, run the following commands from the root of the project:


### PR DESCRIPTION
Fixes #[2038](https://github.com/hackforla/VRMS/issues/2038)


### What changes did you make and why did you make them ?

  - Update GitHub Actions workflow to use actions/upload-artifact@v4 since v3 is deprecated and caused workflow failures.
  - Added missing NVM link in CONTRIBUTING.md
