### PR TITLE
feat: Add On/Offboard Visibility feature for project pages

### DIFF
--- a/backend/controllers/project.controller.js
+++ b/backend/controllers/project.controller.js
@@ -130,4 +130,26 @@ ProjectController.bulkUpdateManagedByUsers = async function (req, res) {
   }
 };
 
+// Update onboard/offboard visibility for a project
+ProjectController.updateOnboardOffboardVisibility = async function (req, res) {
+  const { ProjectId } = req.params;
+  const { onboardOffboardVisible } = req.body;
+
+  try {
+    const project = await Project.findByIdAndUpdate(
+      ProjectId,
+      { onboardOffboardVisible },
+      { new: true }
+    );
+
+    if (!project) {
+      return res.status(404).send({ message: 'Project not found' });
+    }
+
+    return res.status(200).send(project);
+  } catch (err) {
+    return res.status(400).send({ message: 'Error updating visibility', error: err.message });
+  }
+};
+
 module.exports = ProjectController;

--- a/backend/models/project.model.js
+++ b/backend/models/project.model.js
@@ -16,49 +16,51 @@ Idea for the future: programmingLanguages, numberGithubContributions (pull these
 */
 
 const projectSchema = mongoose.Schema({
-    name: { type: String, trim: true },
-    description: { type: String, trim: true },
-    githubIdentifier: { type: String, trim: true },
-    projectStatus: { type: String },                    // Active, Completed, or Paused
-    location: { type: String, trim: true },                         // DTLA, Westside, South LA, or Remote (hacknight)
-    //teamMembers: { type: String },                    // commented since we should be able to get this from Project Team Members table
-    createdDate: { type: Date, default: Date.now },     // date/time project was created
-    completedDate: { type: Date },                      // only if Status = Completed, date/time completed
-    githubUrl: { type: String, trim: true },                        // link to main repo
-    slackUrl: { type: String, trim: true },                         // link to Slack channel
-    googleDriveUrl: { type: String, trim: true },
-    googleDriveId: { type: String },
-    hflaWebsiteUrl: { type: String, trim: true },
-    videoConferenceLink: { type: String },
-    lookingDescription: { type: String },               // narrative on what the project is looking for
-    recruitingCategories: [{ type: String }],           // same as global Skills picklist
-    partners: [{ type: String }],                       // any third-party partners on the project, e.g. City of LA
-    managedByUsers: [{ type: String }]                  // Which users may manage this project.                 
+  name: { type: String, trim: true },
+  description: { type: String, trim: true },
+  githubIdentifier: { type: String, trim: true },
+  projectStatus: { type: String }, // Active, Completed, or Paused
+  location: { type: String, trim: true }, // DTLA, Westside, South LA, or Remote (hacknight)
+  //teamMembers: { type: String },                    // commented since we should be able to get this from Project Team Members table
+  createdDate: { type: Date, default: Date.now }, // date/time project was created
+  completedDate: { type: Date }, // only if Status = Completed, date/time completed
+  githubUrl: { type: String, trim: true }, // link to main repo
+  slackUrl: { type: String, trim: true }, // link to Slack channel
+  googleDriveUrl: { type: String, trim: true },
+  googleDriveId: { type: String },
+  hflaWebsiteUrl: { type: String, trim: true },
+  videoConferenceLink: { type: String },
+  lookingDescription: { type: String }, // narrative on what the project is looking for
+  recruitingCategories: [{ type: String }], // same as global Skills picklist
+  partners: [{ type: String }], // any third-party partners on the project, e.g. City of LA
+  managedByUsers: [{ type: String }], // Which users may manage this project.
+  onboardOffboardVisible: { type: Boolean, default: true }, // Whether onboarding/offboarding forms are visible on the project page
 });
 
-projectSchema.methods.serialize = function() {
-    return {
-        id: this._id,
-        name: this.name,
-        description: this.description,
-        githubIdentifier: this.githubIdentifier,
-        // owner: this.owner,
-        projectStatus: this.projectStatus,
-        location: this.location,
-        //teamMembers: this.teamMembers,
-        createdDate: this.createdDate,
-        completedDate: this.completedDate,
-        githubUrl: this.githubUrl,
-        slackUrl: this.slackUrl,
-        googleDriveUrl: this.googleDriveUrl,
-        googleDriveId: this.googleDriveId,
-        hflaWebsiteUrl: this.hflaWebsiteUrl,
-        videoConferenceLink: this.videoConferenceLink,
-        lookingDescription: this.lookingDescription,
-        recruitingCategories: this.recruitingCategories,
-        partners: this.partners,
-        managedByUsers: this.managedByUsers
-    };
+projectSchema.methods.serialize = function () {
+  return {
+    id: this._id,
+    name: this.name,
+    description: this.description,
+    githubIdentifier: this.githubIdentifier,
+    // owner: this.owner,
+    projectStatus: this.projectStatus,
+    location: this.location,
+    //teamMembers: this.teamMembers,
+    createdDate: this.createdDate,
+    completedDate: this.completedDate,
+    githubUrl: this.githubUrl,
+    slackUrl: this.slackUrl,
+    googleDriveUrl: this.googleDriveUrl,
+    googleDriveId: this.googleDriveId,
+    hflaWebsiteUrl: this.hflaWebsiteUrl,
+    videoConferenceLink: this.videoConferenceLink,
+    lookingDescription: this.lookingDescription,
+    recruitingCategories: this.recruitingCategories,
+    partners: this.partners,
+    managedByUsers: this.managedByUsers,
+    onboardOffboardVisible: this.onboardOffboardVisible,
+  };
 };
 
 const Project = mongoose.model('Project', projectSchema);

--- a/backend/routers/projects.router.js
+++ b/backend/routers/projects.router.js
@@ -22,4 +22,7 @@ router.patch('/:ProjectId', AuthUtil.verifyCookie, ProjectController.updateManag
 // Bulk update for editing project members
 router.post('/bulk-updates', AuthUtil.verifyCookie, ProjectController.bulkUpdateManagedByUsers);
 
+// Update onboard/offboard visibility for a project
+router.patch('/:ProjectId/visibility', AuthUtil.verifyCookie, ProjectController.updateOnboardOffboardVisibility);
+
 module.exports = router;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -29,6 +29,7 @@ import UserWelcome from './pages/UserWelcome';
 // Added User Permission Search component
 import UserPermissionSearch from './pages/UserPermissionSearch';
 import UserPermission from './pages/UserPermission';
+import OnboardOffboardVisibility from './pages/OnboardOffboardVisibility';
 
 import { Box, ThemeProvider } from '@mui/material';
 import theme from './theme';
@@ -69,6 +70,11 @@ const routes = [
     path: '/users/permission-search',
     name: 'useradmin',
     Component: UserPermission,
+  },
+  {
+    path: '/projects/visibility',
+    name: 'onboardoffboardvisibility',
+    Component: withAuth(OnboardOffboardVisibility),
   },
   {
     path: '/projects/:projectId',

--- a/client/src/api/ProjectApiService.js
+++ b/client/src/api/ProjectApiService.js
@@ -148,6 +148,21 @@ class ProjectApiService {
       alert('Server not responding.  Please refresh the page.');
     }
   }
+
+  async updateOnboardOffboardVisibility(projectId, onboardOffboardVisible) {
+    const url = `${this.baseProjectUrl}${projectId}/visibility`;
+    try {
+      const res = await fetch(url, {
+        method: 'PATCH',
+        headers: this.headers,
+        body: JSON.stringify({ onboardOffboardVisible }),
+      });
+      return await res.json();
+    } catch (error) {
+      console.error(`updateOnboardOffboardVisibility error: ${error}`);
+      alert('Server not responding.  Please refresh the page.');
+    }
+  }
 }
 
 export default ProjectApiService;

--- a/client/src/components/manageProjects/editProject.jsx
+++ b/client/src/components/manageProjects/editProject.jsx
@@ -108,7 +108,10 @@ const EditProject = ({
         setFormData={setFormData}
       />
 
-      <TitledBoxIFrame projectName={projectToEdit.name} />
+      {/* Only show onboarding/offboarding forms if visibility is enabled */}
+      {projectToEdit.onboardOffboardVisible !== false && (
+        <TitledBoxIFrame projectName={projectToEdit.name} />
+      )}
 
       {/* Insert Project Members (Event Editors) here */}
       <EditProjectMembers projectToEdit={projectToEdit} />

--- a/client/src/pages/OnboardOffboardVisibility.jsx
+++ b/client/src/pages/OnboardOffboardVisibility.jsx
@@ -1,0 +1,190 @@
+import { useState, useEffect } from 'react';
+import ProjectApiService from '../api/ProjectApiService';
+import TitledBox from '../components/parts/boxes/TitledBox';
+import {
+  Box,
+  CircularProgress,
+  Typography,
+  Switch,
+  Tooltip,
+} from '@mui/material';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+
+/**
+ * On/Offboard Visibility Page
+ *
+ * Allows Admins and Super Admins to control whether the onboarding/offboarding
+ * forms are visible on individual project pages.
+ *
+ * Only accessible to users with accessLevel 'admin' or 'superadmin'.
+ */
+export default function OnboardOffboardVisibility({ auth }) {
+  const [projects, setProjects] = useState(null);
+  const [projectApiService] = useState(new ProjectApiService());
+  const [loading, setLoading] = useState(false);
+
+  const user = auth?.user;
+
+  // Fetch all projects on component mount
+  useEffect(() => {
+    async function fetchAllProjects() {
+      try {
+        const projectData = await projectApiService.fetchProjects();
+        // Sort projects alphabetically
+        const sortedProjects = projectData.sort((a, b) =>
+          a.name?.localeCompare(b.name)
+        );
+        setProjects(sortedProjects);
+      } catch (error) {
+        console.error('Error fetching projects:', error);
+      }
+    }
+
+    fetchAllProjects();
+  }, [projectApiService]);
+
+  // Handle toggle switch change
+  const handleVisibilityToggle = async (projectId, currentValue) => {
+    setLoading(true);
+    try {
+      await projectApiService.updateOnboardOffboardVisibility(
+        projectId,
+        !currentValue
+      );
+
+      // Update local state
+      setProjects((prevProjects) =>
+        prevProjects.map((project) =>
+          project._id === projectId
+            ? { ...project, onboardOffboardVisible: !currentValue }
+            : project
+        )
+      );
+    } catch (error) {
+      console.error('Error updating visibility:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Show loading spinner while projects are being fetched
+  if (!projects) {
+    return (
+      <Box sx={{ textAlign: 'center', pt: 10 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  // Only allow admin or superadmin access
+  if (user?.accessLevel !== 'admin' && user?.accessLevel !== 'superadmin') {
+    return (
+      <Box sx={{ px: 1, py: 3 }}>
+        <Typography variant="h2" textAlign="center" color="error">
+          Access Denied
+        </Typography>
+        <Typography textAlign="center" sx={{ mt: 2 }}>
+          You do not have permission to view this page.
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ px: 1, py: 2 }}>
+      {/* Page Title */}
+      <Box sx={{ my: 3 }}>
+        <Typography variant="h1" textAlign="center">
+          On / Offboard Visibility
+        </Typography>
+      </Box>
+
+      {/* Projects Table in TitledBox */}
+      <TitledBox
+        title="Projects"
+        badge={
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+              minWidth: '150px',
+              justifyContent: 'center',
+            }}
+          >
+            <Typography
+              sx={{
+                fontWeight: 'bold',
+                fontSize: '16px',
+              }}
+            >
+              Visibility
+            </Typography>
+            <Tooltip
+              title="This feature allows Admins and Super Admins to control whether the onboarding/offboarding forms are visible on project pages. Setting a project's visibility to 'No' hides these forms from all users on the associated project's project management page."
+              arrow
+              placement="left"
+            >
+              <InfoOutlinedIcon
+                sx={{
+                  fontSize: '20px',
+                  color: '#666',
+                  cursor: 'pointer',
+                  '&:hover': { color: '#333' },
+                }}
+              />
+            </Tooltip>
+          </Box>
+        }
+        childrenBoxSx={{ p: 0 }}
+      >
+        {/* Project List */}
+        <Box sx={{ maxHeight: '60vh', overflowY: 'auto' }}>
+          {projects.map((project) => (
+            <Box
+              key={project._id}
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: '1fr auto',
+                px: 2,
+                py: 1.5,
+                borderBottom: '1px solid #e0e0e0',
+                '&:hover': { backgroundColor: '#e8e8e8' },
+              }}
+            >
+              <Typography
+                sx={{ fontSize: '14px', display: 'flex', alignItems: 'center' }}
+              >
+                {project.name}
+              </Typography>
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: 1,
+                  minWidth: '150px',
+                }}
+              >
+                <Typography sx={{ fontSize: '14px', minWidth: '35px' }}>
+                  {project.onboardOffboardVisible !== false ? 'Yes' : 'No'}
+                </Typography>
+                <Switch
+                  checked={project.onboardOffboardVisible !== false}
+                  onChange={() =>
+                    handleVisibilityToggle(
+                      project._id,
+                      project.onboardOffboardVisible !== false
+                    )
+                  }
+                  disabled={loading}
+                  color="primary"
+                />
+              </Box>
+            </Box>
+          ))}
+        </Box>
+      </TitledBox>
+    </Box>
+  );
+}

--- a/client/src/pages/ProjectList.jsx
+++ b/client/src/pages/ProjectList.jsx
@@ -83,14 +83,22 @@ export default function ProjectList({ auth }) {
       </Box>
 
       {(user?.accessLevel === 'admin' || user?.accessLevel === 'superadmin') && (
-        <Box sx={{ textAlign: 'center' }}>
+        <Box sx={{ display: 'grid', gridTemplateColumns: 'max-content', gap: 2, justifyContent: 'center', mx: 'auto' }}>
           <Button
             component={Link}
             to="/projects/create"
             variant="secondary"
-            sx={{ mb: 3, px: 4 }}
+            sx={{ px: 4 }}
           >
             Add a New Project
+          </Button>
+          <Button
+            component={Link}
+            to="/projects/visibility"
+            variant="secondary"
+            sx={{ px: 4 }}
+          >
+            On / Offboard Visibility
           </Button>
         </Box>
       )}


### PR DESCRIPTION
Fixes #2046

## Summary
Implements the On/Offboard Visibility feature that allows Admins and Super Admins to control whether onboarding/offboarding forms are visible on individual project pages.

## Changes Made

### Backend
- Added `onboardOffboardVisible` boolean field to project schema (defaults to true)
- Created PATCH `/api/projects/:ProjectId/visibility` endpoint
- Added `updateOnboardOffboardVisibility` controller method

### Frontend
- Created new `OnboardOffboardVisibility` page at `/projects/visibility`
- Added "On / Offboard Visibility" button to Projects page (admin-only)
- Table view displaying all projects with toggle switches
- Info tooltip explaining the feature
- Conditional rendering of onboard/offboard forms based on visibility setting
- Added API service method for visibility updates

<details><summary>Sceenshots</summary>

<img width="529" height="1079" alt="image" src="https://github.com/user-attachments/assets/10e567d7-cb43-49ea-bc67-79bba691ff0a" />

<img width="520" height="1077" alt="image" src="https://github.com/user-attachments/assets/a5742466-40e5-42f0-a9d6-a8d1f547507c" />


</details> 