### PR TITLE
feat(scripts): add modular project deletion script

### DIFF
--- a/backend/scripts/deleteProject/README.md
+++ b/backend/scripts/deleteProject/README.md
@@ -1,0 +1,143 @@
+# Delete Project Script - Modular Structure
+
+This directory contains the modular implementation of the project deletion script.
+
+## File Structure
+
+```
+deleteProject/
+├── README.md          # This file
+├── index.js           # Main orchestration file (entry point)
+├── config.js          # Configuration constants (database names)
+├── utils.js           # Utility functions (validation, CLI parsing, help)
+├── finders.js         # Database query functions (find related records)
+├── displays.js        # Display functions (show detailed information)
+└── deleters.js        # Deletion functions (delete/update operations)
+```
+
+## Module Descriptions
+
+### `index.js`
+
+Main orchestration file that coordinates the entire deletion process.
+
+- Parses command-line arguments
+- Validates input and environment
+- Connects to MongoDB
+- Orchestrates the find → display → delete workflow
+- Handles errors and cleanup
+
+### `config.js`
+
+Configuration constants used throughout the script.
+
+- Database names (production, development, test)
+- Can be extended with other configuration values
+
+### `utils.js`
+
+Utility and helper functions.
+
+- `checkEnv()` - Validates required environment variables
+- `isValidObjectId()` - Validates MongoDB ObjectId format
+- `getProjectIdFromArgs()` - Extracts project ID from CLI arguments
+- `printHelp()` - Displays usage information
+
+### `finders.js`
+
+Database query functions for finding related records.
+
+- `findProject()` - Find the project by ID
+- `findProjectEvents()` - Find all events for the project
+- `findEventCheckIns()` - Find all check-ins for project events
+- `findProjectTeamMembers()` - Find team members
+- `findUsersReferencingProject()` - Find users with project references
+- `findRelatedRecurringEvents()` - Find recurring events
+
+### `displays.js`
+
+Display functions for showing detailed record information.
+
+- `displayUserDetails()` - Show user information
+- `displayEventDetails()` - Show event information
+- `displayCheckInDetails()` - Show check-in information (with user lookup)
+- `displayProjectTeamMemberDetails()` - Show team member information
+- `displayRecurringEventDetails()` - Show recurring event information
+
+### `deleters.js`
+
+Deletion and update functions.
+
+- `deleteCheckIns()` - Delete check-in records
+- `deleteProjectTeamMembers()` - Delete team member records
+- `updateUsersRemoveProject()` - Remove project references from users
+- `deleteEvents()` - Delete event records
+- `deleteRecurringEvents()` - Delete recurring event records
+- `deleteProject()` - Delete the project itself
+
+## Usage
+
+### From the deleteProject directory:
+
+```bash
+node index.js --project-id=<PROJECT_ID> [options]
+```
+
+### From the scripts directory (backwards compatible):
+
+```bash
+node deleteProjectAndAssociatedRecords.js --project-id=<PROJECT_ID> [options]
+```
+
+### Options:
+
+- `--project-id=<ID>` - MongoDB ObjectId of the project to delete (REQUIRED)
+- `--prod` - Operate on production database
+- `--live` - Operate on development/staging database
+- `--test` - Operate on test database
+- `--mock` - Dry run (no actual deletion)
+- `--execute` - Execute the deletion
+- `--help` - Show help message
+
+## Examples
+
+```bash
+# Dry run on production
+node index.js --project-id=644748563212e6001fbca24a --prod --mock
+
+# Execute on test database
+node index.js --project-id=644748563212e6001fbca24a --test --execute
+
+# Execute on production (with 5-second warning)
+node index.js --project-id=644748563212e6001fbca24a --prod --execute
+```
+
+## Safety Features
+
+1. **Mock mode** - Preview all changes before executing
+2. **5-second warning** - Countdown for production/live databases
+3. **Validation** - Validates project ID and environment variables
+4. **Detailed output** - Shows exactly what will be deleted
+5. **Orphan detection** - Identifies orphaned check-ins
+
+## Deletion Order
+
+The script follows this order to maintain referential integrity:
+
+1. Check-ins
+2. Project team members
+3. User references (updated, not deleted)
+4. Events
+5. Recurring events
+6. Project
+
+## Environment Requirements
+
+- `MIGRATION_DB_URI` - MongoDB connection string
+
+Load from `backend/.env` file.
+
+## See Also
+
+- Main documentation: `tmp/GUIDE.md`
+- Manual deletion steps for MongoDB Compass users

--- a/backend/scripts/deleteProject/config.js
+++ b/backend/scripts/deleteProject/config.js
@@ -1,0 +1,14 @@
+/**
+ * Configuration constants for project deletion script
+ */
+
+// Database names
+const PROD_DB_NAME = 'db'; // Actual production database
+const DEV_DB_NAME = 'vrms-test'; // Development/staging database
+const DEV_TEST_DB_NAME = 'vrms-populate-projects-test'; // Test database for migration
+
+module.exports = {
+  PROD_DB_NAME,
+  DEV_DB_NAME,
+  DEV_TEST_DB_NAME,
+};

--- a/backend/scripts/deleteProject/deleters.js
+++ b/backend/scripts/deleteProject/deleters.js
@@ -1,0 +1,175 @@
+/**
+ * Deletion functions for removing project-related records
+ */
+
+const { ObjectId } = require('mongodb');
+
+/**
+ * Delete check-ins
+ * @param {Db} db - MongoDB database instance
+ * @param {Array} checkIns - Array of check-in documents
+ * @param {boolean} isMock - If true, only print what would be deleted
+ * @returns {Promise<void>}
+ */
+async function deleteCheckIns(db, checkIns, isMock) {
+  if (checkIns.length === 0) {
+    console.log('[INFO] No check-ins to delete.');
+    return;
+  }
+
+  if (isMock) {
+    console.log(`[MOCK] Would delete ${checkIns.length} check-in(s).`);
+    return;
+  }
+
+  const checkInIds = checkIns.map((ci) => ci._id);
+  const result = await db.collection('checkins').deleteMany({ _id: { $in: checkInIds } });
+
+  console.log(`[SUCCESS] Deleted ${result.deletedCount} check-in(s).`);
+}
+
+/**
+ * Delete project team members
+ * @param {Db} db - MongoDB database instance
+ * @param {string} projectId - The project ID
+ * @param {boolean} isMock - If true, only print what would be deleted
+ * @returns {Promise<void>}
+ */
+async function deleteProjectTeamMembers(db, projectId, isMock) {
+  const count = await db.collection('projectteammembers').countDocuments({ projectId: projectId });
+
+  if (count === 0) {
+    console.log('[INFO] No project team members to delete.');
+    return;
+  }
+
+  if (isMock) {
+    console.log(`[MOCK] Would delete ${count} project team member(s).`);
+    return;
+  }
+
+  const result = await db.collection('projectteammembers').deleteMany({ projectId: projectId });
+
+  console.log(`[SUCCESS] Deleted ${result.deletedCount} project team member(s).`);
+}
+
+/**
+ * Update users to remove project references
+ * @param {Db} db - MongoDB database instance
+ * @param {string} projectId - The project ID
+ * @param {Array} users - Array of user documents
+ * @param {boolean} isMock - If true, only print what would be updated
+ * @returns {Promise<void>}
+ */
+async function updateUsersRemoveProject(db, projectId, users, isMock) {
+  if (users.length === 0) {
+    console.log('[INFO] No users to update.');
+    return;
+  }
+
+  if (isMock) {
+    console.log(`[MOCK] Would update ${users.length} user(s) to remove project references.`);
+    users.forEach((user) => {
+      const hasInProjects = user.projects?.some((pid) => String(pid) === projectId);
+      const hasInManagedProjects = user.managedProjects?.includes(projectId);
+      console.log(`       - User: ${user.name?.firstName} ${user.name?.lastName} (${user.email})`);
+      if (hasInProjects) console.log(`         * Remove from 'projects' array`);
+      if (hasInManagedProjects) console.log(`         * Remove from 'managedProjects' array`);
+    });
+    return;
+  }
+
+  const operations = users.map((user) => ({
+    updateOne: {
+      filter: { _id: user._id },
+      update: {
+        $pull: {
+          projects: new ObjectId(projectId),
+          managedProjects: projectId,
+        },
+      },
+    },
+  }));
+
+  const result = await db.collection('users').bulkWrite(operations, { ordered: false });
+
+  console.log(`[SUCCESS] Updated ${result.modifiedCount} user(s) to remove project references.`);
+}
+
+/**
+ * Delete events
+ * @param {Db} db - MongoDB database instance
+ * @param {string} projectId - The project ID
+ * @param {boolean} isMock - If true, only print what would be deleted
+ * @returns {Promise<void>}
+ */
+async function deleteEvents(db, projectId, isMock) {
+  const count = await db.collection('events').countDocuments({ project: new ObjectId(projectId) });
+
+  if (count === 0) {
+    console.log('[INFO] No events to delete.');
+    return;
+  }
+
+  if (isMock) {
+    console.log(`[MOCK] Would delete ${count} event(s).`);
+    return;
+  }
+
+  const result = await db.collection('events').deleteMany({ project: new ObjectId(projectId) });
+
+  console.log(`[SUCCESS] Deleted ${result.deletedCount} event(s).`);
+}
+
+/**
+ * Delete recurring events
+ * @param {Db} db - MongoDB database instance
+ * @param {Array} recurringEvents - Array of recurring event documents
+ * @param {boolean} isMock - If true, only print what would be deleted
+ * @returns {Promise<void>}
+ */
+async function deleteRecurringEvents(db, recurringEvents, isMock) {
+  if (recurringEvents.length === 0) {
+    console.log('[INFO] No recurring events to delete.');
+    return;
+  }
+
+  if (isMock) {
+    console.log(`[MOCK] Would delete ${recurringEvents.length} recurring event(s).`);
+    return;
+  }
+
+  const recurringEventIds = recurringEvents.map((re) => re._id);
+  const result = await db
+    .collection('recurringevents')
+    .deleteMany({ _id: { $in: recurringEventIds } });
+
+  console.log(`[SUCCESS] Deleted ${result.deletedCount} recurring event(s).`);
+}
+
+/**
+ * Delete the project
+ * @param {Db} db - MongoDB database instance
+ * @param {string} projectId - The project ID
+ * @param {boolean} isMock - If true, only print what would be deleted
+ * @returns {Promise<void>}
+ */
+async function deleteProject(db, projectId, isMock) {
+  if (isMock) {
+    console.log(`[MOCK] Would delete project: ${projectId}`);
+    return;
+  }
+
+  const result = await db.collection('projects').deleteOne({ _id: new ObjectId(projectId) });
+
+  console.log(`[SUCCESS] Deleted ${result.deletedCount} project.`);
+}
+
+module.exports = {
+  deleteCheckIns,
+  deleteProjectTeamMembers,
+  updateUsersRemoveProject,
+  deleteEvents,
+  deleteRecurringEvents,
+  deleteProject,
+};

--- a/backend/scripts/deleteProject/displays.js
+++ b/backend/scripts/deleteProject/displays.js
@@ -1,0 +1,288 @@
+/**
+ * Display functions for showing detailed information about records
+ */
+
+const { ObjectId } = require('mongodb');
+
+/**
+ * Display detailed information about users
+ * @param {Array} users - Array of user documents
+ * @param {string} projectId - The project ID
+ * @returns {void}
+ */
+function displayUserDetails(users, projectId) {
+  if (users.length === 0) {
+    console.log('  No users reference this project.\n');
+    return;
+  }
+
+  console.log(`\n${'─'.repeat(60)}`);
+  console.log('USERS REFERENCING THIS PROJECT');
+  console.log(`${'─'.repeat(60)}\n`);
+
+  users.forEach((user, index) => {
+    const hasInProjects = user.projects?.some((pid) => String(pid) === projectId);
+    const hasInManagedProjects = user.managedProjects?.includes(projectId);
+
+    console.log(`User ${index + 1}/${users.length}:`);
+    console.log(`  Name: ${user.name?.firstName || 'N/A'} ${user.name?.lastName || 'N/A'}`);
+    console.log(`  Email: ${user.email || 'N/A'}`);
+    console.log(`  User ID: ${user._id}`);
+    console.log(`  Access Level: ${user.accessLevel || 'N/A'}`);
+    console.log(`  Is Active: ${user.isActive !== undefined ? user.isActive : 'N/A'}`);
+
+    if (hasInProjects) {
+      console.log(`  ⚠ In 'projects' array (total projects: ${user.projects?.length || 0})`);
+    }
+    if (hasInManagedProjects) {
+      console.log(
+        `  ⚠ In 'managedProjects' array (total managed: ${user.managedProjects?.length || 0})`,
+      );
+    }
+
+    console.log('');
+  });
+}
+
+/**
+ * Display detailed information about events
+ * @param {Array} events - Array of event documents
+ * @returns {void}
+ */
+function displayEventDetails(events) {
+  if (events.length === 0) {
+    console.log('  No events associated with this project.\n');
+    return;
+  }
+
+  console.log(`\n${'─'.repeat(60)}`);
+  console.log('EVENTS ASSOCIATED WITH THIS PROJECT');
+  console.log(`${'─'.repeat(60)}\n`);
+
+  // Group events by type
+  const eventsByType = {};
+  events.forEach((event) => {
+    const type = event.eventType || 'Unknown';
+    if (!eventsByType[type]) {
+      eventsByType[type] = [];
+    }
+    eventsByType[type].push(event);
+  });
+
+  // Display summary by type
+  console.log('Event Summary by Type:');
+  Object.entries(eventsByType).forEach(([type, evts]) => {
+    console.log(`  ${type}: ${evts.length} event(s)`);
+  });
+  console.log('');
+
+  // Display first 10 events in detail, then summarize the rest
+  const displayLimit = 10;
+  const eventsToDisplay = events.slice(0, displayLimit);
+
+  console.log(`Showing first ${eventsToDisplay.length} of ${events.length} event(s):\n`);
+
+  eventsToDisplay.forEach((event, index) => {
+    console.log(`Event ${index + 1}/${events.length}:`);
+    console.log(`  Event ID: ${event._id}`);
+    console.log(`  Name: ${event.name || 'N/A'}`);
+    console.log(`  Type: ${event.eventType || 'N/A'}`);
+    console.log(`  Location: ${event.hacknight || event.location?.city || 'N/A'}`);
+    console.log(`  Date: ${event.date ? new Date(event.date).toLocaleDateString() : 'N/A'}`);
+    console.log(
+      `  Start Time: ${event.startTime ? new Date(event.startTime).toLocaleString() : 'N/A'}`,
+    );
+    console.log(`  Check-In Ready: ${event.checkInReady || false}`);
+
+    if (event.recurringEventLink?.recurringEventId) {
+      console.log(`  ⚠ Part of recurring event: ${event.recurringEventLink.recurringEventId}`);
+    }
+
+    console.log('');
+  });
+
+  if (events.length > displayLimit) {
+    console.log(`... and ${events.length - displayLimit} more event(s)\n`);
+  }
+}
+
+/**
+ * Display detailed information about check-ins
+ * @param {Array} checkIns - Array of check-in documents
+ * @param {Array} events - Array of event documents for reference
+ * @param {Db} db - MongoDB database instance (optional, for user lookup)
+ * @returns {Promise<void>}
+ */
+async function displayCheckInDetails(checkIns, events, db) {
+  if (checkIns.length === 0) {
+    console.log('  No check-ins associated with project events.\n');
+    return;
+  }
+
+  console.log(`\n${'─'.repeat(60)}`);
+  console.log('CHECK-INS ASSOCIATED WITH PROJECT EVENTS');
+  console.log(`${'─'.repeat(60)}\n`);
+
+  // Group check-ins by event
+  const checkInsByEvent = {};
+  const uniqueUserIds = new Set();
+
+  checkIns.forEach((checkIn) => {
+    const eventId = checkIn.eventId;
+    if (!checkInsByEvent[eventId]) {
+      checkInsByEvent[eventId] = [];
+    }
+    checkInsByEvent[eventId].push(checkIn);
+    if (checkIn.userId) {
+      uniqueUserIds.add(checkIn.userId);
+    }
+  });
+
+  console.log(`Total check-ins: ${checkIns.length}`);
+  console.log(`Spread across ${Object.keys(checkInsByEvent).length} event(s)`);
+  console.log(`Unique users: ${uniqueUserIds.size}\n`);
+
+  // Fetch user information if db is provided
+  let users = [];
+  if (db && uniqueUserIds.size > 0) {
+    const userIdArray = Array.from(uniqueUserIds);
+    users = await db
+      .collection('users')
+      .find({ _id: { $in: userIdArray.map((id) => new ObjectId(id)) } })
+      .toArray();
+  }
+
+  console.log('Check-ins by Event:');
+  Object.entries(checkInsByEvent).forEach(([eventId, eventCheckIns]) => {
+    const event = events.find((e) => String(e._id) === eventId);
+    const eventName = event?.name || 'Unknown Event';
+    const eventDate = event?.date ? new Date(event.date).toLocaleDateString() : 'Unknown Date';
+    console.log(`  ${eventName} (${eventDate}): ${eventCheckIns.length} check-in(s)`);
+  });
+  console.log('');
+
+  // Display user information
+  if (users.length > 0 || uniqueUserIds.size > 0) {
+    console.log('Users who checked in:');
+
+    // Count check-ins per user
+    const checkInCountByUser = {};
+    checkIns.forEach((checkIn) => {
+      const userId = checkIn.userId;
+      if (!checkInCountByUser[userId]) {
+        checkInCountByUser[userId] = 0;
+      }
+      checkInCountByUser[userId]++;
+    });
+
+    users.forEach((user) => {
+      const userId = String(user._id);
+      const checkInCount = checkInCountByUser[userId] || 0;
+      const userName = `${user.name?.firstName || 'N/A'} ${user.name?.lastName || 'N/A'}`;
+      const userEmail = user.email || 'N/A';
+      console.log(`  ${userName} (${userEmail}): ${checkInCount} check-in(s)`);
+    });
+
+    // Check for orphaned check-ins (userIds without matching users)
+    const foundUserIds = new Set(users.map((u) => String(u._id)));
+    const orphanedUserIds = Array.from(uniqueUserIds).filter((id) => !foundUserIds.has(id));
+
+    if (orphanedUserIds.length > 0) {
+      console.log('\n⚠️  Orphaned check-ins (user not found in database):');
+      orphanedUserIds.forEach((userId) => {
+        const checkInCount = checkInCountByUser[userId] || 0;
+        console.log(`  User ID: ${userId}: ${checkInCount} check-in(s)`);
+        console.log(`    → This user no longer exists in the database`);
+      });
+    }
+
+    console.log('');
+  }
+}
+
+/**
+ * Display detailed information about project team members
+ * @param {Array} teamMembers - Array of project team member documents
+ * @returns {void}
+ */
+function displayProjectTeamMemberDetails(teamMembers) {
+  if (teamMembers.length === 0) {
+    console.log('  No project team members.\n');
+    return;
+  }
+
+  console.log(`\n${'─'.repeat(60)}`);
+  console.log('PROJECT TEAM MEMBERS');
+  console.log(`${'─'.repeat(60)}\n`);
+
+  // Group by status
+  const activeMembers = teamMembers.filter((m) => m.teamMemberStatus === 'Active');
+  const inactiveMembers = teamMembers.filter((m) => m.teamMemberStatus !== 'Active');
+
+  console.log(`Total team members: ${teamMembers.length}`);
+  console.log(`  Active: ${activeMembers.length}`);
+  console.log(`  Inactive: ${inactiveMembers.length}\n`);
+
+  teamMembers.forEach((member, index) => {
+    console.log(`Team Member ${index + 1}/${teamMembers.length}:`);
+    console.log(`  User ID: ${member.userId}`);
+    console.log(`  Status: ${member.teamMemberStatus || 'N/A'}`);
+    console.log(`  Role: ${member.roleOnProject || 'N/A'}`);
+    console.log(`  VRMS Admin: ${member.vrmsProjectAdmin || false}`);
+    console.log(
+      `  Joined: ${member.joinedDate ? new Date(member.joinedDate).toLocaleDateString() : 'N/A'}`,
+    );
+
+    if (member.leftDate) {
+      console.log(`  Left: ${new Date(member.leftDate).toLocaleDateString()}`);
+      console.log(`  Left Reason: ${member.leftReason || 'N/A'}`);
+    }
+
+    console.log('');
+  });
+}
+
+/**
+ * Display information about related recurring events
+ * @param {Array} recurringEvents - Array of recurring event documents
+ * @returns {void}
+ */
+function displayRecurringEventDetails(recurringEvents) {
+  if (recurringEvents.length === 0) {
+    console.log('  No recurring events associated with this project.\n');
+    return;
+  }
+
+  console.log(`\n${'─'.repeat(60)}`);
+  console.log('RECURRING EVENTS ASSOCIATED WITH THIS PROJECT');
+  console.log(`${'─'.repeat(60)}\n`);
+
+  console.log(`${recurringEvents.length} recurring event(s) will be deleted.\n`);
+
+  recurringEvents.forEach((recurringEvent, index) => {
+    console.log(`Recurring Event ${index + 1}/${recurringEvents.length}:`);
+    console.log(`  Recurring Event ID: ${recurringEvent._id}`);
+    console.log(`  Project ID: ${recurringEvent.project || 'N/A'}`);
+
+    // Display recurring event details if available
+    if (recurringEvent.name) {
+      console.log(`  Name: ${recurringEvent.name}`);
+    }
+    if (recurringEvent.eventType) {
+      console.log(`  Type: ${recurringEvent.eventType}`);
+    }
+    if (recurringEvent.hacknight) {
+      console.log(`  Location: ${recurringEvent.hacknight}`);
+    }
+
+    console.log('');
+  });
+}
+
+module.exports = {
+  displayUserDetails,
+  displayEventDetails,
+  displayCheckInDetails,
+  displayProjectTeamMemberDetails,
+  displayRecurringEventDetails,
+};

--- a/backend/scripts/deleteProject/finders.js
+++ b/backend/scripts/deleteProject/finders.js
@@ -1,0 +1,128 @@
+/**
+ * Database query functions for finding related records
+ */
+
+const { ObjectId } = require('mongodb');
+
+/**
+ * Find the project by ID
+ * @param {Db} db - MongoDB database instance
+ * @param {string} projectId - The project ID
+ * @returns {Promise<Object|null>} Project document or null
+ */
+async function findProject(db, projectId) {
+  const project = await db.collection('projects').findOne({ _id: new ObjectId(projectId) });
+
+  if (!project) {
+    console.log(`[ERROR] Project not found: ${projectId}`);
+    return null;
+  }
+
+  console.log(`[INFO] Found project: "${project.name}" (${projectId})`);
+  return project;
+}
+
+/**
+ * Find all events associated with the project
+ * @param {Db} db - MongoDB database instance
+ * @param {string} projectId - The project ID
+ * @returns {Promise<Array>} Array of event documents
+ */
+async function findProjectEvents(db, projectId) {
+  const events = await db
+    .collection('events')
+    .find({ project: new ObjectId(projectId) })
+    .toArray();
+
+  console.log(`[INFO] Found ${events.length} event(s) for this project.`);
+  return events;
+}
+
+/**
+ * Find all check-ins associated with the project events
+ * @param {Db} db - MongoDB database instance
+ * @param {Array} events - Array of event documents
+ * @returns {Promise<Array>} Array of check-in documents
+ */
+async function findEventCheckIns(db, events) {
+  if (events.length === 0) {
+    console.log('[INFO] No events, so no check-ins to delete.');
+    return [];
+  }
+
+  const eventIds = events.map((event) => String(event._id));
+  const checkIns = await db
+    .collection('checkins')
+    .find({ eventId: { $in: eventIds } })
+    .toArray();
+
+  console.log(`[INFO] Found ${checkIns.length} check-in(s) for project events.`);
+  return checkIns;
+}
+
+/**
+ * Find all project team members for the project
+ * @param {Db} db - MongoDB database instance
+ * @param {string} projectId - The project ID
+ * @returns {Promise<Array>} Array of project team member documents
+ */
+async function findProjectTeamMembers(db, projectId) {
+  const teamMembers = await db
+    .collection('projectteammembers')
+    .find({ projectId: projectId })
+    .toArray();
+
+  console.log(`[INFO] Found ${teamMembers.length} project team member(s).`);
+  return teamMembers;
+}
+
+/**
+ * Find all users who reference this project
+ * @param {Db} db - MongoDB database instance
+ * @param {string} projectId - The project ID
+ * @returns {Promise<Array>} Array of user documents
+ */
+async function findUsersReferencingProject(db, projectId) {
+  const users = await db
+    .collection('users')
+    .find({
+      $or: [{ projects: new ObjectId(projectId) }, { managedProjects: projectId }],
+    })
+    .toArray();
+
+  console.log(`[INFO] Found ${users.length} user(s) referencing this project.`);
+  return users;
+}
+
+/**
+ * Check for recurring events that may be affected
+ * @param {Db} db - MongoDB database instance
+ * @param {Array} events - Array of event documents
+ * @returns {Promise<Array>} Array of recurring event IDs
+ */
+async function findRelatedRecurringEvents(db, events) {
+  const recurringEventIds = events
+    .filter((e) => e.recurringEventLink?.recurringEventId)
+    .map((e) => e.recurringEventLink.recurringEventId)
+    .filter((id, index, self) => self.indexOf(id) === index); // unique
+
+  if (recurringEventIds.length === 0) {
+    return [];
+  }
+
+  const recurringEvents = await db
+    .collection('recurringevents')
+    .find({ _id: { $in: recurringEventIds.map((id) => new ObjectId(id)) } })
+    .toArray();
+
+  return recurringEvents;
+}
+
+module.exports = {
+  findProject,
+  findProjectEvents,
+  findEventCheckIns,
+  findProjectTeamMembers,
+  findUsersReferencingProject,
+  findRelatedRecurringEvents,
+};

--- a/backend/scripts/deleteProject/index.js
+++ b/backend/scripts/deleteProject/index.js
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+
+/**
+ * Script to delete a project and all associated records from the database.
+ *
+ * This script performs a cascading deletion of:
+ * - Check-ins associated with project events
+ * - Project team members
+ * - Project references from users (projects and managedProjects arrays)
+ * - Events associated with the project
+ * - Recurring events associated with the project
+ * - The project itself
+ *
+ * Usage:
+ *   node index.js --project-id=<PROJECT_ID> [options]
+ *
+ * Options:
+ *   --project-id=<ID>    The MongoDB ObjectId of the project to delete (REQUIRED)
+ *   --prod               Operate on production database (db)
+ *   --live               Operate on development/staging database (vrms-test)
+ *   --test               Operate on test database (vrms-populate-projects-test)
+ *   --mock               Only print what would be deleted, do not delete (dry run)
+ *   --execute            Execute the deletion (actually delete from the database)
+ *   --help               Show this help message and exit
+ *   (no flags)           Show help (safety mode)
+ *
+ * Requires environment variable:
+ *   MIGRATION_DB_URI  - MongoDB connection string for migration
+ *
+ * Examples:
+ *   node index.js --project-id=644748563212e6001fbca24a --test --mock
+ *   node index.js --project-id=644748563212e6001fbca24a --test --execute
+ *   node index.js --project-id=644748563212e6001fbca24a --live --execute
+ *   node index.js --project-id=644748563212e6001fbca24a --prod --execute
+ *
+ * See documentation: tmp/GUIDE.md
+ */
+
+const { MongoClient } = require('mongodb');
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '../../.env') });
+
+// Import modules
+const { PROD_DB_NAME, DEV_DB_NAME, DEV_TEST_DB_NAME } = require('./config');
+const { checkEnv, getProjectIdFromArgs, printHelp } = require('./utils');
+const {
+  findProject,
+  findProjectEvents,
+  findEventCheckIns,
+  findProjectTeamMembers,
+  findUsersReferencingProject,
+  findRelatedRecurringEvents,
+} = require('./finders');
+const {
+  displayUserDetails,
+  displayEventDetails,
+  displayCheckInDetails,
+  displayProjectTeamMemberDetails,
+  displayRecurringEventDetails,
+} = require('./displays');
+const {
+  deleteCheckIns,
+  deleteProjectTeamMembers,
+  updateUsersRemoveProject,
+  deleteEvents,
+  deleteRecurringEvents,
+  deleteProject,
+} = require('./deleters');
+
+/**
+ * Main coordinator function
+ */
+async function main() {
+  const isProd = process.argv.includes('--prod');
+  const isLive = process.argv.includes('--live');
+  const isTest = process.argv.includes('--test');
+  const isMock = process.argv.includes('--mock');
+  const isExecute = process.argv.includes('--execute');
+  const isHelp = process.argv.includes('--help');
+  const noArgs = process.argv.length <= 2;
+
+  if (isHelp || noArgs) {
+    printHelp();
+    return;
+  }
+
+  // Check environment only after help check
+  checkEnv();
+
+  // Get project ID
+  let projectId;
+  try {
+    projectId = getProjectIdFromArgs();
+    if (!projectId) {
+      console.error('[ERROR] --project-id is required.');
+      printHelp();
+      process.exitCode = 1;
+      return;
+    }
+  } catch (err) {
+    console.error(`[ERROR] ${err.message}`);
+    printHelp();
+    process.exitCode = 1;
+    return;
+  }
+
+  // Check that only one database flag is specified
+  const dbFlags = [isProd, isLive, isTest].filter(Boolean);
+  if (dbFlags.length > 1) {
+    console.error(
+      '[ERROR] Cannot specify multiple database flags. Choose one: --prod, --live, or --test.',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  if (dbFlags.length === 0) {
+    console.error('[ERROR] Must specify a database: --prod, --live, or --test.');
+    printHelp();
+    process.exitCode = 1;
+    return;
+  }
+
+  if (isMock && isExecute) {
+    console.error('[ERROR] Cannot specify both --mock and --execute. Choose one.');
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!isMock && !isExecute) {
+    console.error('[ERROR] Must specify either --mock (dry run) or --execute (actual deletion).');
+    printHelp();
+    process.exitCode = 1;
+    return;
+  }
+
+  // Determine database name and mode label
+  let dbName, modeLabel;
+  if (isProd) {
+    dbName = PROD_DB_NAME;
+    modeLabel = 'PRODUCTION';
+  } else if (isLive) {
+    dbName = DEV_DB_NAME;
+    modeLabel = 'DEVELOPMENT/STAGING';
+  } else {
+    dbName = DEV_TEST_DB_NAME;
+    modeLabel = 'TEST';
+  }
+
+  console.log(`\n${'='.repeat(60)}`);
+  console.log(`DELETE PROJECT AND ASSOCIATED RECORDS`);
+  console.log(
+    `Mode: ${modeLabel} ${
+      isMock ? '(DRY RUN - No changes will be made)' : '(EXECUTE - Will DELETE from database)'
+    }`,
+  );
+  console.log(`Database: ${dbName}`);
+  console.log(`Project ID: ${projectId}`);
+  console.log(`${'='.repeat(60)}\n`);
+
+  if ((isProd || isLive) && isExecute) {
+    console.log(
+      `[WARNING] Operating on ${modeLabel} database with EXECUTE mode. This will DELETE data!`,
+    );
+    console.log(`[WARNING] Press Ctrl+C within 5 seconds to cancel...`);
+    await new Promise((resolve) => setTimeout(resolve, 5000)); // 5 seconds for prod/live
+  }
+
+  let client;
+  try {
+    // Connect to MongoDB
+    client = new MongoClient(process.env.MIGRATION_DB_URI);
+    await client.connect();
+    console.log('[INFO] Connected to MongoDB.\n');
+
+    const db = client.db(dbName);
+
+    // Step 0: Verify project exists
+    const project = await findProject(db, projectId);
+    if (!project) {
+      console.log('[ERROR] Cannot proceed without a valid project.');
+      process.exitCode = 1;
+      return;
+    }
+
+    console.log('\n--- GATHERING RECORDS TO DELETE ---\n');
+
+    // Step 1: Find all events for this project
+    const events = await findProjectEvents(db, projectId);
+
+    // Step 2: Find all check-ins for those events
+    const checkIns = await findEventCheckIns(db, events);
+
+    // Step 3: Find all project team members
+    const teamMembers = await findProjectTeamMembers(db, projectId);
+
+    // Step 4: Find all users referencing this project
+    const users = await findUsersReferencingProject(db, projectId);
+
+    // Step 5: Check for recurring events
+    const recurringEvents = await findRelatedRecurringEvents(db, events);
+    if (recurringEvents.length > 0) {
+      console.log(
+        `[INFO] Found ${recurringEvents.length} recurring event(s) associated with this project.`,
+      );
+    }
+
+    console.log('\n--- DELETION PLAN SUMMARY ---\n');
+    console.log(`  Check-ins to delete: ${checkIns.length}`);
+    console.log(`  Project team members to delete: ${teamMembers.length}`);
+    console.log(`  Users to update: ${users.length}`);
+    console.log(`  Events to delete: ${events.length}`);
+    console.log(`  Recurring events to delete: ${recurringEvents.length}`);
+    console.log(`  Projects to delete: 1`);
+    console.log('');
+
+    // Display detailed information about all records
+    displayUserDetails(users, projectId);
+    displayProjectTeamMemberDetails(teamMembers);
+    displayEventDetails(events);
+    await displayCheckInDetails(checkIns, events, db);
+    displayRecurringEventDetails(recurringEvents);
+
+    if (isMock) {
+      console.log('[MOCK] This is a dry run. No changes will be made.\n');
+    } else {
+      console.log('[EXECUTE] Beginning deletion process...\n');
+    }
+
+    console.log('--- EXECUTING DELETIONS (in order) ---\n');
+
+    // Step 6: Delete check-ins
+    await deleteCheckIns(db, checkIns, isMock);
+
+    // Step 7: Delete project team members
+    await deleteProjectTeamMembers(db, projectId, isMock);
+
+    // Step 8: Update users to remove project references
+    await updateUsersRemoveProject(db, projectId, users, isMock);
+
+    // Step 9: Delete events
+    await deleteEvents(db, projectId, isMock);
+
+    // Step 10: Delete recurring events
+    await deleteRecurringEvents(db, recurringEvents, isMock);
+
+    // Step 11: Delete the project
+    await deleteProject(db, projectId, isMock);
+
+    console.log(`\n${'='.repeat(60)}`);
+    if (isMock) {
+      console.log('[MOCK] Dry run completed. No changes were made.');
+    } else {
+      console.log('[SUCCESS] Project and all associated records deleted successfully.');
+    }
+    console.log(`${'='.repeat(60)}\n`);
+  } catch (err) {
+    console.error('[ERROR]', err.message);
+    console.error(err.stack);
+    process.exitCode = 1;
+  } finally {
+    if (client) {
+      await client.close();
+      console.log('[INFO] Database connection closed.');
+    }
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { main };

--- a/backend/scripts/deleteProject/utils.js
+++ b/backend/scripts/deleteProject/utils.js
@@ -1,0 +1,56 @@
+/**
+ * Utility functions for project deletion script
+ */
+
+const { ObjectId } = require('mongodb');
+const { PROD_DB_NAME, DEV_DB_NAME, DEV_TEST_DB_NAME } = require('./config');
+
+/**
+ * Validate required environment variables
+ */
+function checkEnv() {
+  if (!process.env.MIGRATION_DB_URI) {
+    throw new Error('MIGRATION_DB_URI environment variable must be set.');
+  }
+}
+
+/**
+ * Validate if a string is a valid MongoDB ObjectId
+ * @param {string} id - The ID to validate
+ * @returns {boolean}
+ */
+function isValidObjectId(id) {
+  return ObjectId.isValid(id) && String(new ObjectId(id)) === id;
+}
+
+/**
+ * Extract project ID from command line arguments
+ * @returns {string|null} Project ID or null if not found
+ */
+function getProjectIdFromArgs() {
+  const projectIdArg = process.argv.find((arg) => arg.startsWith('--project-id='));
+  if (!projectIdArg) return null;
+
+  const projectId = projectIdArg.split('=')[1];
+  if (!projectId || !isValidObjectId(projectId)) {
+    throw new Error(`Invalid project ID: ${projectId}`);
+  }
+
+  return projectId;
+}
+
+/**
+ * Print help message for CLI usage
+ */
+function printHelp() {
+  console.log(
+    `\nUsage: node deleteProjectAndAssociatedRecords.js --project-id=<PROJECT_ID> [options]\n\nOptions:\n  --project-id=<ID>  The MongoDB ObjectId of the project to delete (REQUIRED)\n  --prod             Operate on PRODUCTION database (${PROD_DB_NAME})\n  --live             Operate on development/staging database (${DEV_DB_NAME})\n  --test             Operate on test database (${DEV_TEST_DB_NAME})\n  --mock             Only print what would be deleted, do not delete (dry run)\n  --execute          Execute the deletion (actually delete from the database)\n  --help             Show this help message and exit\n\nExamples:\n  node deleteProjectAndAssociatedRecords.js --project-id=644748563212e6001fbca24a --test --mock\n  node deleteProjectAndAssociatedRecords.js --project-id=644748563212e6001fbca24a --test --execute\n  node deleteProjectAndAssociatedRecords.js --project-id=644748563212e6001fbca24a --live --execute\n  node deleteProjectAndAssociatedRecords.js --project-id=644748563212e6001fbca24a --prod --execute\n\nDocumentation:\n  See tmp/GUIDE.md for details\n`,
+  );
+}
+
+module.exports = {
+  checkEnv,
+  isValidObjectId,
+  getProjectIdFromArgs,
+  printHelp,
+};

--- a/backend/scripts/deleteProjectAndAssociatedRecords.js
+++ b/backend/scripts/deleteProjectAndAssociatedRecords.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+/**
+ * Wrapper script for backwards compatibility.
+ * The actual implementation has been moved to ./deleteProject/index.js
+ *
+ * This script simply delegates to the modular implementation.
+ */
+
+const { main } = require('./deleteProject/index');
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = require('./deleteProject/index');


### PR DESCRIPTION
Fixes #2047

## Summary

Script to delete a project and remove all references to that project from the database.

**How it works:**
- Finds all records related to the project (events, check-ins, team members, recurring events)
- Displays detailed information about what will be deleted, including affected users
- Removes project references from user records without deleting the users
- Deletes all related records in the correct order to maintain referential integrity
- Provides mock mode to preview changes before executing

## Features

- Modular structure with single-responsibility modules for maintainability
- User lookup for check-ins showing which users are affected
- Orphan detection for check-ins with deleted users
- Recurring events deletion support
- Detailed output showing all related records before deletion
- Mock mode for safe dry runs
- 5-second warning for production databases
- Validation of project ID and environment variables

## Usage

```bash
# Dry run to see what would be deleted
node backend/scripts/deleteProjectAndAssociatedRecords.js --project-id=<ID> --prod --mock

# Execute the deletion
node backend/scripts/deleteProjectAndAssociatedRecords.js --project-id=<ID> --prod --execute
```

## Deletion Order
1. Check-ins
2. Project team members
3. User references (updated, not deleted)
4. Events
5. Recurring events
6. Project