### PR TITLE
Disable admin toggling for self as admin or superadmin

### DIFF
--- a/client/src/components/user-admin/EditUsers.jsx
+++ b/client/src/components/user-admin/EditUsers.jsx
@@ -16,6 +16,7 @@ import {
   InputLabel,
 } from '@mui/material';
 import '../../sass/UserAdmin.scss';
+import useAuth from '../../hooks/useAuth';
 
 // child of UserAdmin. Displays form to update users.
 const EditUsers = ({
@@ -30,6 +31,10 @@ const EditUsers = ({
   const [projectValue, setProjectValue] = useState(''); // State and handler for form in EditUsers
   const [isActive, setIsActive] = useState(userToEdit.isActive);
   const [isAdmin, setIsAdmin] = useState(userToEdit.accessLevel === 'admin');
+  const { auth } = useAuth();
+
+  console.log('user to edit', userToEdit);
+  console.log('auth user', auth?.user);
 
   // Boolean to check if the current user is the super admin
   const isSuperAdmin = userToEdit.accessLevel === 'superadmin';
@@ -64,7 +69,6 @@ const EditUsers = ({
     ) {
       const newProjects = [...userManagedProjects, projectValue];
       updateUserDb(userToEdit, projectValue, 'add');
-      // updateUserDb(userToEdit, newProjects);
       setUserManagedProjects(newProjects);
       setProjectValue('');
     } else {
@@ -78,7 +82,6 @@ const EditUsers = ({
         (p) => p !== projectToRemove
       );
       updateUserDb(userToEdit, projectToRemove, 'remove');
-      // updateUserDb(userToEdit, newProjects);
       setUserManagedProjects(newProjects);
     }
   };
@@ -128,7 +131,8 @@ const EditUsers = ({
             <Switch
               checked={isAdmin || isSuperAdmin}
               onChange={handleSetAccessLevel}
-              disabled={isSuperAdmin}
+              disabled={isSuperAdmin || userToEdit._id === auth?.user._id}
+              sx={{ cursor: (isSuperAdmin || userToEdit._id === auth?.user._id) ? "not-allowed" : "pointer" }}
             />
           }
           label={isAdmin || isSuperAdmin ? 'Yes' : 'No'}

--- a/client/src/components/user-admin/EditUsers.jsx
+++ b/client/src/components/user-admin/EditUsers.jsx
@@ -18,7 +18,7 @@ import {
 import '../../sass/UserAdmin.scss';
 import useAuth from '../../hooks/useAuth';
 
-// child of UserAdmin. Displays form to update users.
+
 const EditUsers = ({
   userToEdit,
   backToSearch,
@@ -32,9 +32,6 @@ const EditUsers = ({
   const [isActive, setIsActive] = useState(userToEdit.isActive);
   const [isAdmin, setIsAdmin] = useState(userToEdit.accessLevel === 'admin');
   const { auth } = useAuth();
-
-  console.log('user to edit', userToEdit);
-  console.log('auth user', auth?.user);
 
   // Boolean to check if the current user is the super admin
   const isSuperAdmin = userToEdit.accessLevel === 'superadmin';
@@ -51,8 +48,6 @@ const EditUsers = ({
   useEffect(() => {
     setUserManagedProjects(userToEdit.managedProjects);
   }, [userToEdit]);
-
-  console.log(userManagedProjects)
 
   const userProjectsToDisplay = activeProjects.filter((item) =>
     userProjects.includes(item[0])

--- a/client/src/components/user-admin/UserManagement.jsx
+++ b/client/src/components/user-admin/UserManagement.jsx
@@ -9,7 +9,8 @@ import {
   ListItem,
   ListItemButton,
 } from '@mui/material';
-
+import useAuth from '../../hooks/useAuth';
+import PersonIcon from '@mui/icons-material/Person';
 import '../../sass/UserAdmin.scss';
 
 const Buttonsx = {
@@ -21,6 +22,7 @@ const UserManagement = ({ users, setUserToEdit }) => {
   let searchResults = [];
   const [searchResultType, setSearchResultType] = useState('name'); // Which results will diplay
   const [searchTerm, setSearchTerm] = useState(''); // Serch term for the user/email search
+  const { auth } = useAuth();
 
   // Swaps the buttons and displayed panels for the search results, by email or by name
   const buttonSwap = () =>
@@ -141,8 +143,8 @@ const UserManagement = ({ users, setUserToEdit }) => {
                       onClick={() => setUserToEdit(u)}
                     >
                       {searchResultType === 'name'
-                        ? `${u.name?.firstName} ${u.name?.lastName} ( ${u.email} )`
-                        : `${u.email} ( ${u.name?.firstName} ${u.name?.lastName} )`}
+                        ?  (u._id === auth.user._id) ? (<><PersonIcon /><b>{u.name?.firstName} {u.name?.lastName} ( {u.email} )</b></>) : `${u.name?.firstName} ${u.name?.lastName} ( ${u.email} )`
+                        :  (u._id === auth.user._id) ? (<><PersonIcon /><b>{u.email} ( {u.name?.firstName} {u.name?.lastName} )</b></>) : `${u.email} ( ${u.name?.firstName} ${u.name?.lastName} )`}
                     </ListItemButton>
                   </ListItem>
                 );

--- a/client/src/components/user-admin/UserPermissionSearch.jsx
+++ b/client/src/components/user-admin/UserPermissionSearch.jsx
@@ -11,7 +11,8 @@ import {
   ListItemButton,
 } from '@mui/material';
 import { useLocation } from 'react-router-dom';
-
+import useAuth from '../../hooks/useAuth';
+import PersonIcon from '@mui/icons-material/Person';
 import '../../sass/UserAdmin.scss';
 
 const Buttonsx = {
@@ -20,6 +21,7 @@ const Buttonsx = {
 };
 
 const DummyComponent = ({ data, isProjectLead, setUserToEdit }) => {
+  const { auth } = useAuth();
   return (
     <List className="search-results disablePadding">
       {data.map((u, idx) => {
@@ -50,7 +52,9 @@ const DummyComponent = ({ data, isProjectLead, setUserToEdit }) => {
               <Grid container>
                 <Grid item>
                   <Typography style={{ fontWeight: 600 }}>
-                    {`${name.firstName.toUpperCase()} ${name.lastName.toUpperCase()} ( ${email.toUpperCase()} )`}
+                    {(_id === auth?.user?._id) ? 
+                      (<><PersonIcon /><b>{`${name.firstName.toUpperCase()} ${name.lastName.toUpperCase()} ( ${email.toUpperCase()} )`}</b></>) 
+                      : `${name.firstName.toUpperCase()} ${name.lastName.toUpperCase()} ( ${email.toUpperCase()} )`}
                   </Typography>
                 </Grid>
               </Grid>
@@ -81,13 +85,13 @@ const DummyComponent = ({ data, isProjectLead, setUserToEdit }) => {
               <Grid container justifyContent={'space-between'}>
                 <Grid item>
                   <Typography style={{ fontWeight: 600 }}>
-                    {name.firstName.toUpperCase() +
-                      ' ' +
-                      name.lastName.toUpperCase()}
+                      {(_id === auth?.user?._id) ? 
+                      (<><PersonIcon /><b>{`${name.firstName.toUpperCase()} ${name.lastName.toUpperCase()}`}</b></>) :
+                      `${name.firstName.toUpperCase()} ${name.lastName.toUpperCase()}`}
                   </Typography>
                 </Grid>
                 <Grid item>
-                  <Typography style={{ fontWeight: 600 }} color="black">
+                  <Typography style={{ fontWeight: (_id === auth?.user?._id) ? 'bold' : 600 }}>
                     {u.managedProjectName}
                   </Typography>
                 </Grid>


### PR DESCRIPTION
Fixes #2043

### What changes did you make and why did you make them ?
  - added profile icon and bold text of currently logged in user in all searches
  - disabled toggling of admin status for logged in users who are `admins` and `superadmins`

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<details>
<summary>Visuals before changes are applied</summary>

<img width="400" height="500" alt="image" src="https://github.com/user-attachments/assets/8ebe9964-cbf4-49d0-91ba-61fc48bf8ca4" />

<img width="400" height="500" alt="image" src="https://github.com/user-attachments/assets/d6ad68cb-3aa5-4895-8374-dd0aeccdf441" />

</details>

<details>
<summary>Visuals after changes are applied</summary>

<img width="400" height="500" alt="image" src="https://github.com/user-attachments/assets/990c9312-aabb-421a-a3f6-1a86cbd72939" />

<img width="400" height="500" alt="image" src="https://github.com/user-attachments/assets/209993df-2667-462b-bf9e-bb21c7e531af" />


</details>
