### PR TITLE
Fix: Correct Dockerfile syntax errors in production build

### DIFF
--- a/client/Dockerfile.prod
+++ b/client/Dockerfile.prod
@@ -3,7 +3,7 @@ RUN mkdir /srv/client && chown node:node /srv/client
 WORKDIR /srv/client
 USER node
 RUN mkdir -p node_modules
-COPY --chown=node:node package.json package.json ./
+COPY --chown=node:node package*.json ./
 RUN npm install --no-update-notifier
 
 FROM node:20-alpine AS client-builder
@@ -12,8 +12,8 @@ WORKDIR /srv/client
 COPY --from=node-modules-install /srv/client/node_modules node_modules
 COPY . .
 USER root
-ARG CUSTOM_REQUEST_HEADER nAb3kY-S%qE#4!d
-ENV REACT_APP_CUSTOM_REQUEST_HEADER $CUSTOM_REQUEST_HEADER
+ARG CUSTOM_REQUEST_HEADER=nAb3kY-S%qE#4!d
+ENV REACT_APP_CUSTOM_REQUEST_HEADER=$CUSTOM_REQUEST_HEADER
 RUN npm run build
 
 FROM nginx as client-production


### PR DESCRIPTION
## Summary
Fixed two pre-existing syntax errors in the frontend production Dockerfile (`client/Dockerfile.prod`).

## Background
These syntax errors were present in the Dockerfile but were never caught because the build was failing earlier due to code issues (fixed in PR #2086). Once the code issues were resolved, these Dockerfile syntax problems would have prevented the build from succeeding.

## Changes

### 1. Fixed COPY command syntax (Line 6)
**Before:**
```dockerfile
COPY --chown=node:node package.json package.json ./
```

**After:**
```dockerfile
COPY --chown=node:node package*.json ./
```

**Reason:** The original command attempted to copy `package.json` twice, which is invalid Docker syntax. The corrected version uses a glob pattern to copy `package.json` and `package-lock.json` (if present), matching the pattern used in `backend/Dockerfile.prod:5`.

### 2. Fixed ARG and ENV directive syntax (Lines 15-16)
**Before:**
```dockerfile
ARG CUSTOM_REQUEST_HEADER nAb3kY-S%qE#4!d
ENV REACT_APP_CUSTOM_REQUEST_HEADER $CUSTOM_REQUEST_HEADER
```

**After:**
```dockerfile
ARG CUSTOM_REQUEST_HEADER=nAb3kY-S%qE#4!d
ENV REACT_APP_CUSTOM_REQUEST_HEADER=$CUSTOM_REQUEST_HEADER
```

**Reason:** Docker ARG and ENV directives require an equals sign between the variable name and value for proper syntax compliance.

## Testing
- [ ] Trigger the "Frontend Build and Deploy" workflow to verify Docker build succeeds
- [ ] Verify the Docker image builds without syntax errors
- [ ] Confirm the application runs correctly with the built image

## Related
- Depends on PR #2086 (code fixes must be merged first, otherwise build will still fail)
- These fixes can be merged independently but should be merged after #2086

🤖 Generated with [Claude Code](https://claude.ai/code)