### PR TITLE
fix(docker): update Node versions to 24 and mount shared directory

### DIFF
--- a/backend/Dockerfile.api
+++ b/backend/Dockerfile.api
@@ -1,4 +1,4 @@
-FROM node:18.12.0 AS api-development
+FROM node:24-alpine AS api-development
 RUN mkdir /srv/backend
 WORKDIR /srv/backend
 RUN mkdir -p node_modules
@@ -6,14 +6,14 @@ COPY package.json yarn.lock ./
 RUN yarn install --pure-lockfile
 COPY . .
 
-FROM node:18.12.0 AS api-test
+FROM node:24-alpine AS api-test
 RUN mkdir /srv/backend
 WORKDIR /srv/backend
 COPY package.json yarn.lock ./
 RUN yarn install --silent
 RUN mkdir -p node_modules
 
-FROM node:18.12.0-slim AS api-production
+FROM node:24-alpine AS api-production
 EXPOSE 4000
 USER node
 WORKDIR /srv/backend

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:18.12.0 AS api-development
+FROM node:24-alpine AS api-development
 RUN mkdir /srv/backend
 WORKDIR /srv/backend
 RUN mkdir -p node_modules

--- a/client/Dockerfile.client
+++ b/client/Dockerfile.client
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS client-development
+FROM node:24-alpine AS client-development
 RUN mkdir /srv/client && chown node:node /srv/client
 WORKDIR /srv/client
 USER node
@@ -6,7 +6,7 @@ RUN mkdir -p node_modules
 COPY --chown=node:node package.json package.json ./
 RUN npm install --silent
 
-FROM node:20-alpine AS client-builder
+FROM node:24-alpine AS client-builder
 USER node
 WORKDIR /srv/client
 COPY --from=client-development /srv/client/node_modules node_modules

--- a/client/Dockerfile.dev
+++ b/client/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:18-alpine AS client-development
+FROM node:24-alpine AS client-development
 RUN mkdir /srv/client && chown node:node /srv/client
 WORKDIR /srv/client
 USER node

--- a/client/Dockerfile.prod
+++ b/client/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS node-modules-install
+FROM node:24-alpine AS node-modules-install
 RUN mkdir /srv/client && chown node:node /srv/client
 WORKDIR /srv/client
 USER node
@@ -6,7 +6,7 @@ RUN mkdir -p node_modules
 COPY --chown=node:node package*.json ./
 RUN npm install --no-update-notifier
 
-FROM node:20-alpine AS client-builder
+FROM node:24-alpine AS client-builder
 USER node
 WORKDIR /srv/client
 COPY --from=node-modules-install /srv/client/node_modules node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     command: yarn run dev
     volumes:
       - ./backend:/srv/backend
+      - ./shared:/srv/shared
       - backend_node_modules:/srv/backend/node_modules
     expose:
       - "4000"


### PR DESCRIPTION
## Summary
- Update all Dockerfiles from Node 18/20 to Node 24-alpine to match `.nvmrc`
- Mount `shared/` directory in docker-compose so backend can resolve `../../shared/authorizationUtils` at runtime

## Changed files
- `backend/Dockerfile.dev` — node:18.12.0 → node:24-alpine
- `backend/Dockerfile.api` — node:18.12.0 → node:24-alpine (all 3 stages)
- `client/Dockerfile.dev` — node:18-alpine → node:24-alpine
- `client/Dockerfile.client` — node:20-alpine → node:24-alpine
- `client/Dockerfile.prod` — node:20-alpine → node:24-alpine
- `docker-compose.yml` — add `./shared:/srv/shared` volume to backend service

## Test plan
- [ ] Run `docker compose up backend client --build` and verify both services start
- [ ] Confirm backend no longer crashes with `Cannot find module '../../shared/authorizationUtils'`
- [ ] Verify Node version inside containers matches `.nvmrc` (24)