### PR TITLE
fix: refactor checkin workers for testability and timezone safety (#1872)

### DIFF
--- a/backend/workers/closeCheckins.js
+++ b/backend/workers/closeCheckins.js
@@ -1,75 +1,78 @@
+import adjustToLosAngelesTime from './lib/adjustToLosAngelesTime.js';
+
+const THREE_HOURS_MS = 10800000;
+
+// --- Testable pure function (exported) ---
+
+export function filterEventsToClose(events, now) {
+  if (!events || events.length === 0) return [];
+
+  const laNow = adjustToLosAngelesTime(now);
+  const laNowMs = laNow.getTime();
+
+  return events.filter((event) => {
+    if (!event.date) return false;
+    const eventDate = new Date(event.date);
+    if (Number.isNaN(eventDate.getTime())) return false;
+    const startMs = adjustToLosAngelesTime(eventDate).getTime();
+    const threeHoursFromStart = startMs + THREE_HOURS_MS;
+    return laNowMs >= threeHoursFromStart && event.checkInReady === true;
+  });
+}
+
+// --- Side-effectful functions ---
+
+async function fetchEvents(url, headerToSend, fetch) {
+  try {
+    const res = await fetch(`${url}/api/events`, {
+      headers: { 'x-customrequired-header': headerToSend },
+    });
+    return await res.json();
+  } catch (error) {
+    console.log(error);
+    return [];
+  }
+}
+
+async function updateEvents(url, headerToSend, fetch, eventsToUpdate) {
+  try {
+    const res = await fetch(`${url}/api/events/batchUpdate`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-customrequired-header': headerToSend,
+      },
+      body: JSON.stringify(eventsToUpdate),
+    });
+    if (!res.ok) throw new Error('Failed to update event');
+    return await res.json();
+  } catch (error) {
+    console.error('Error updating event:', error);
+    return null;
+  }
+}
+
+// --- Entrypoint ---
+
 export default (cron, fetch) => {
   const url =
     process.env.NODE_ENV === 'prod'
       ? 'https://www.vrms.io'
-      : `http://localhost:${process.env.BACKEND_PORT}`;
-  const headerToSend = process.env.CUSTOM_REQUEST_HEADER;
+      : `http://localhost:${process.env.BACKEND_PORT || 4000}`;
+  const headerToSend = process.env.CUSTOM_REQUEST_HEADER ?? '';
 
-  async function fetchEvents() {
-    try {
-      const res = await fetch(`${url}/api/events`, {
-        headers: {
-          'x-customrequired-header': headerToSend,
-        },
-      });
-      const resJson = await res.json();
+  async function runTask() {
+    console.log('Closing check-ins');
 
-      return resJson;
-    } catch (error) {
-      console.log(error);
-    }
-  }
+    const events = await fetchEvents(url, headerToSend, fetch);
+    const eventsToClose = filterEventsToClose(events, new Date());
 
-  async function updateEvents(eventsToUpdate) {
-    try {
-      const res = await fetch(`${url}/api/events/batchUpdate`, {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-customrequired-header': headerToSend,
-        },
-        body: JSON.stringify(eventsToUpdate),
-      });
-      if (!res.ok) throw new Error('Failed to update event');
-      return await res.json();
-    } catch (error) {
-      console.error('Error updating event:', error);
-      return null;
-    }
-  }
-
-  async function sortAndFilterEvents() {
-    const events = await fetchEvents();
-
-    // Get current time and set to date variable
-    const now = new Date();
-    const laNow = new Date(now.toLocaleString('en-US', { timeZone: 'America/Los_Angeles' }));
-    const laNowMs = laNow.getTime();
-    // Filter events if event date is after now but before thirty minutes from now
-    if (events && events.length > 0) {
-      const sortedEvents = events.filter((event) => {
-        if (!event.date) {
-          // handle if event date is null/undefined
-          // false meaning don't include in sortedEvents
-          return false;
-        }
-        const threeHoursFromStartTime = new Date(event.date).getTime() + 10800000;
-        if (Number.isNaN(threeHoursFromStartTime)) return false;
-        return laNowMs >= threeHoursFromStartTime && event.checkInReady === true;
-      });
-
-      return sortedEvents;
-    }
-  }
-
-  async function closeCheckins(events) {
-    if (events && events.length > 0) {
-      console.log('Closing check-ins');
-      const batchEventsToUpdate = events.map((e) => ({
+    if (eventsToClose.length > 0) {
+      const batchEventsToUpdate = eventsToClose.map((e) => ({
         _id: e._id,
         checkInReady: false,
       }));
-      const updatedEvents = await updateEvents(batchEventsToUpdate);
+      const updatedEvents = await updateEvents(url, headerToSend, fetch, batchEventsToUpdate);
       if (updatedEvents) console.log('Updated events:', updatedEvents);
       console.log('Check-ins closed');
     } else {
@@ -77,19 +80,7 @@ export default (cron, fetch) => {
     }
   }
 
-  async function runTask() {
-    const eventsToClose = await sortAndFilterEvents().catch((err) => {
-      console.log(err);
-    });
-
-    await closeCheckins(eventsToClose).catch((err) => {
-      console.log(err);
-    });
-  }
-
-  const scheduledTask = cron.schedule('*/30 * * * *', () => {
+  return cron.schedule('*/30 * * * *', () => {
     runTask();
   });
-
-  return scheduledTask;
 };

--- a/backend/workers/closeCheckins.js
+++ b/backend/workers/closeCheckins.js
@@ -1,72 +1,78 @@
-export default (cron, fetch) => {
-  // Check to see if any events are about to start,
-  // and if so, open their respective check-ins
+import adjustToLosAngelesTime from './lib/adjustToLosAngelesTime.js';
 
+const THREE_HOURS_MS = 10800000;
+
+// --- Testable pure function (exported) ---
+
+export function filterEventsToClose(events, now) {
+  if (!events || events.length === 0) return [];
+
+  const laNow = adjustToLosAngelesTime(now);
+  const laNowMs = laNow.getTime();
+
+  return events.filter((event) => {
+    if (!event.date) return false;
+    const eventDate = new Date(event.date);
+    if (Number.isNaN(eventDate.getTime())) return false;
+    const startMs = adjustToLosAngelesTime(eventDate).getTime();
+    const threeHoursFromStart = startMs + THREE_HOURS_MS;
+    return laNowMs >= threeHoursFromStart && event.checkInReady === true;
+  });
+}
+
+// --- Side-effectful functions ---
+
+async function fetchEvents(url, headerToSend, fetch) {
+  try {
+    const res = await fetch(`${url}/api/events`, {
+      headers: { 'x-customrequired-header': headerToSend },
+    });
+    return await res.json();
+  } catch (error) {
+    console.log(error);
+    return [];
+  }
+}
+
+async function updateEvents(url, headerToSend, fetch, eventsToUpdate) {
+  try {
+    const res = await fetch(`${url}/api/events/batchUpdate`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-customrequired-header': headerToSend,
+      },
+      body: JSON.stringify(eventsToUpdate),
+    });
+    if (!res.ok) throw new Error('Failed to update event');
+    return await res.json();
+  } catch (error) {
+    console.error('Error updating event:', error);
+    return null;
+  }
+}
+
+// --- Entrypoint ---
+
+export default (cron, fetch) => {
   const url =
     process.env.NODE_ENV === 'prod'
       ? 'https://www.vrms.io'
-      : `http://localhost:${process.env.BACKEND_PORT}`;
-  const headerToSend = process.env.CUSTOM_REQUEST_HEADER;
+      : `http://localhost:${process.env.BACKEND_PORT || 4000}`;
+  const headerToSend = process.env.CUSTOM_REQUEST_HEADER ?? '';
 
-  async function fetchEvents() {
-    try {
-      const res = await fetch(`${url}/api/events`, {
-        headers: {
-          'x-customrequired-header': headerToSend,
-        },
-      });
-      const resJson = await res.json();
+  async function runTask() {
+    console.log('Closing check-ins');
 
-      return resJson;
-    } catch (error) {
-      console.log(error);
-    }
-  }
+    const events = await fetchEvents(url, headerToSend, fetch);
+    const eventsToClose = filterEventsToClose(events, new Date());
 
-  async function updateEvents(eventsToUpdate) {
-    try {
-      const res = await fetch(`${url}/api/events/batchUpdate`, {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-customrequired-header': headerToSend,
-        },
-        body: JSON.stringify(eventsToUpdate),
-      });
-      if (!res.ok) throw new Error('Failed to update event');
-      return await res.json();
-    } catch (error) {
-      console.error('Error updating event:', error);
-      return null;
-    }
-  }
-  async function sortAndFilterEvents() {
-    const events = await fetchEvents();
-
-    const now = Date.now();
-
-    if (events && events.length > 0) {
-      const sortedEvents = events.filter((event) => {
-        if (!event.date) {
-          return false;
-        }
-        const threeHoursFromStartTime = new Date(event.date).getTime() + 10800000;
-        if (Number.isNaN(threeHoursFromStartTime)) return false;
-        return now >= threeHoursFromStartTime && event.checkInReady === true;
-      });
-
-      return sortedEvents;
-    }
-  }
-
-  async function closeCheckins(events) {
-    if (events && events.length > 0) {
-      console.log('Closing check-ins');
-      const batchEventsToUpdate = events.map((e) => ({
+    if (eventsToClose.length > 0) {
+      const batchEventsToUpdate = eventsToClose.map((e) => ({
         _id: e._id,
         checkInReady: false,
       }));
-      const updatedEvents = await updateEvents(batchEventsToUpdate);
+      const updatedEvents = await updateEvents(url, headerToSend, fetch, batchEventsToUpdate);
       if (updatedEvents) console.log('Updated events:', updatedEvents);
       console.log('Check-ins closed');
     } else {
@@ -74,19 +80,7 @@ export default (cron, fetch) => {
     }
   }
 
-  async function runTask() {
-    const eventsToClose = await sortAndFilterEvents().catch((err) => {
-      console.log(err);
-    });
-
-    await closeCheckins(eventsToClose).catch((err) => {
-      console.log(err);
-    });
-  }
-
-  const scheduledTask = cron.schedule('*/30 * * * *', () => {
+  return cron.schedule('*/30 * * * *', () => {
     runTask();
   });
-
-  return scheduledTask;
 };

--- a/backend/workers/closeCheckins.test.js
+++ b/backend/workers/closeCheckins.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import MockDate from 'mockdate';
+
+// Unmock — vitest.setup.js globally mocks all workers
+vi.unmock('./closeCheckins.js');
+
+import { filterEventsToClose } from './closeCheckins.js';
+
+describe('closeCheckins — filterEventsToClose', () => {
+  afterEach(() => {
+    MockDate.reset();
+  });
+
+  const makeEvent = (date, checkInReady = true) => ({
+    _id: `evt-${date}`,
+    name: 'Test Event',
+    date,
+    checkInReady,
+  });
+
+  // --- Basic behavior ---
+
+  it('returns empty array when no events', () => {
+    expect(filterEventsToClose([], new Date())).toEqual([]);
+    expect(filterEventsToClose(null, new Date())).toEqual([]);
+  });
+
+  it('skips events with no date', () => {
+    const events = [{ _id: '1', name: 'No Date', checkInReady: true }];
+    expect(filterEventsToClose(events, new Date())).toEqual([]);
+  });
+
+  it('skips events with invalid date strings', () => {
+    const events = [makeEvent('not-a-date', true)];
+    expect(filterEventsToClose(events, new Date())).toEqual([]);
+  });
+
+  it('skips events not open for check-in', () => {
+    MockDate.set('2024-01-15T23:00:00Z');
+    const events = [makeEvent('2024-01-15T19:00:00Z', false)];
+    expect(filterEventsToClose(events, new Date())).toEqual([]);
+  });
+
+  it('closes event 3+ hours after start', () => {
+    MockDate.set('2024-01-15T22:05:00Z');
+    const events = [makeEvent('2024-01-15T19:00:00Z', true)];
+    const result = filterEventsToClose(events, new Date());
+    expect(result).toHaveLength(1);
+  });
+
+  it('does NOT close event less than 3 hours after start', () => {
+    MockDate.set('2024-01-15T21:00:00Z');
+    const events = [makeEvent('2024-01-15T19:00:00Z', true)];
+    expect(filterEventsToClose(events, new Date())).toEqual([]);
+  });
+
+  it('closes event exactly at 3 hours after start', () => {
+    MockDate.set('2024-01-15T22:00:00Z');
+    const events = [makeEvent('2024-01-15T19:00:00Z', true)];
+    const result = filterEventsToClose(events, new Date());
+    expect(result).toHaveLength(1);
+  });
+
+  // --- DST: timezone-aware comparison ---
+
+  it('spring forward: event closes 3h after start during PDT', () => {
+    // Event at 03:00 UTC, 3h later = 06:00 UTC. At 06:05 UTC → close.
+    MockDate.set('2024-03-13T06:05:00Z');
+    const events = [makeEvent('2024-03-13T03:00:00Z', true)];
+    const result = filterEventsToClose(events, new Date());
+    expect(result).toHaveLength(1);
+  });
+
+  it('spring forward: event does NOT close before 3h during PDT', () => {
+    MockDate.set('2024-03-13T05:05:00Z'); // only 2h5m after start
+    const events = [makeEvent('2024-03-13T03:00:00Z', true)];
+    expect(filterEventsToClose(events, new Date())).toHaveLength(0);
+  });
+
+  it('fall back: event closes 3h after start during PST', () => {
+    // Event at 02:00 UTC, 3h later = 05:00 UTC. At 05:05 UTC → close.
+    MockDate.set('2024-11-06T05:05:00Z');
+    const events = [makeEvent('2024-11-06T02:00:00Z', true)];
+    const result = filterEventsToClose(events, new Date());
+    expect(result).toHaveLength(1);
+  });
+
+  it('fall back: event does NOT close before 3h during PST', () => {
+    MockDate.set('2024-11-06T04:55:00Z'); // only 2h55m after start
+    const events = [makeEvent('2024-11-06T02:00:00Z', true)];
+    expect(filterEventsToClose(events, new Date())).toHaveLength(0);
+  });
+
+  // --- Multiple events ---
+
+  it('handles multiple events, returning only eligible ones', () => {
+    MockDate.set('2024-01-15T22:05:00Z');
+    const events = [
+      makeEvent('2024-01-15T19:00:00Z', true), // 3h5m ago, open → close
+      makeEvent('2024-01-15T20:00:00Z', true), // 2h5m ago, open → skip
+      makeEvent('2024-01-15T18:00:00Z', true), // 4h5m ago, open → close
+      makeEvent('2024-01-15T19:00:00Z', false), // 3h5m ago, already closed → skip
+    ];
+    const result = filterEventsToClose(events, new Date());
+    expect(result).toHaveLength(2);
+  });
+});

--- a/backend/workers/lib/adjustToLosAngelesTime.js
+++ b/backend/workers/lib/adjustToLosAngelesTime.js
@@ -1,0 +1,17 @@
+// Extracted from createRecurringEvents.js for shared use across workers.
+// Converts a UTC date to LA local time by computing the current UTC offset
+// for America/Los_Angeles (handles PST/PDT automatically).
+const adjustToLosAngelesTime = (eventDate) => {
+  const tempDate = new Date(eventDate);
+  const losAngelesOffsetHours = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Los_Angeles',
+    timeZoneName: 'shortOffset',
+  })
+    .formatToParts(tempDate)
+    .find((part) => part.type === 'timeZoneName')
+    .value.slice(3);
+  const offsetMinutes = parseInt(losAngelesOffsetHours, 10) * 60;
+  return new Date(tempDate.getTime() + offsetMinutes * 60000);
+};
+
+export default adjustToLosAngelesTime;

--- a/backend/workers/lib/adjustToLosAngelesTime.test.js
+++ b/backend/workers/lib/adjustToLosAngelesTime.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import adjustToLosAngelesTime from './adjustToLosAngelesTime.js';
+
+describe('adjustToLosAngelesTime', () => {
+  it('should adjust UTC to PST (winter, UTC-8)', () => {
+    const utc = new Date('2024-01-15T08:00:00Z');
+    const result = adjustToLosAngelesTime(utc);
+    // 08:00 UTC - 8h = 00:00 LA time
+    expect(result.toISOString()).toBe('2024-01-15T00:00:00.000Z');
+  });
+
+  it('should adjust UTC to PDT (summer, UTC-7)', () => {
+    const utc = new Date('2024-07-15T07:00:00Z');
+    const result = adjustToLosAngelesTime(utc);
+    // 07:00 UTC - 7h = 00:00 LA time
+    expect(result.toISOString()).toBe('2024-07-15T00:00:00.000Z');
+  });
+
+  it('should handle day before DST starts (PST, UTC-8)', () => {
+    const utc = new Date('2024-03-10T07:00:00Z');
+    const result = adjustToLosAngelesTime(utc);
+    // Mar 10 07:00 UTC — still PST at this point (spring forward happens at 2am PST = 10:00 UTC)
+    // 07:00 - 8h = Mar 9 23:00
+    expect(result.toISOString()).toBe('2024-03-09T23:00:00.000Z');
+  });
+
+  it('should handle day after DST starts (PDT, UTC-7)', () => {
+    const utc = new Date('2024-03-11T07:00:00Z');
+    const result = adjustToLosAngelesTime(utc);
+    // 07:00 UTC - 7h = 00:00 LA time
+    expect(result.toISOString()).toBe('2024-03-11T00:00:00.000Z');
+  });
+
+  it('should handle day after DST ends (PST, UTC-8)', () => {
+    const utc = new Date('2024-11-04T08:00:00Z');
+    const result = adjustToLosAngelesTime(utc);
+    // 08:00 UTC - 8h = 00:00 LA time
+    expect(result.toISOString()).toBe('2024-11-04T00:00:00.000Z');
+  });
+
+  it('should accept string dates', () => {
+    const result = adjustToLosAngelesTime('2024-01-15T08:00:00Z');
+    expect(result.toISOString()).toBe('2024-01-15T00:00:00.000Z');
+  });
+});

--- a/backend/workers/openCheckins.js
+++ b/backend/workers/openCheckins.js
@@ -1,73 +1,78 @@
-export default (cron, fetch) => {
-  // Check to see if any events are about to start,
-  // and if so, open their respective check-ins
+import adjustToLosAngelesTime from './lib/adjustToLosAngelesTime.js';
 
+const THIRTY_MINUTES_MS = 1800000;
+
+// --- Testable pure function (exported) ---
+
+export function filterEventsToOpen(events, now) {
+  if (!events || events.length === 0) return [];
+
+  const laNow = adjustToLosAngelesTime(now);
+  const laNowMs = laNow.getTime();
+  const thirtyMinutesFromNow = laNowMs + THIRTY_MINUTES_MS;
+
+  return events.filter((event) => {
+    if (!event.date) return false;
+    const eventDate = new Date(event.date);
+    if (Number.isNaN(eventDate.getTime())) return false;
+    const startMs = adjustToLosAngelesTime(eventDate).getTime();
+    return startMs >= laNowMs && startMs <= thirtyMinutesFromNow && event.checkInReady === false;
+  });
+}
+
+// --- Side-effectful functions ---
+
+async function fetchEvents(url, headerToSend, fetch) {
+  try {
+    const res = await fetch(`${url}/api/events`, {
+      headers: { 'x-customrequired-header': headerToSend },
+    });
+    return await res.json();
+  } catch (error) {
+    console.log(error);
+    return [];
+  }
+}
+
+async function updateEvents(url, headerToSend, fetch, eventsToUpdate) {
+  try {
+    const res = await fetch(`${url}/api/events/batchUpdate`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-customrequired-header': headerToSend,
+      },
+      body: JSON.stringify(eventsToUpdate),
+    });
+    if (!res.ok) throw new Error('Failed to update event');
+    return await res.json();
+  } catch (error) {
+    console.error('Error updating event:', error);
+    return null;
+  }
+}
+
+// --- Entrypoint ---
+
+export default (cron, fetch) => {
   const url =
     process.env.NODE_ENV === 'prod'
       ? 'https://www.vrms.io'
-      : `http://localhost:${process.env.BACKEND_PORT}`;
-  const headerToSend = process.env.CUSTOM_REQUEST_HEADER;
+      : `http://localhost:${process.env.BACKEND_PORT || 4000}`;
+  const headerToSend = process.env.CUSTOM_REQUEST_HEADER ?? '';
 
-  async function fetchEvents() {
-    try {
-      const res = await fetch(`${url}/api/events`, {
-        headers: {
-          'x-customrequired-header': headerToSend,
-        },
-      });
-      const resJson = await res.json();
+  async function runTask() {
+    console.log('Opening check-ins');
 
-      return resJson;
-    } catch (error) {
-      console.log(error);
-    }
-  }
+    const events = await fetchEvents(url, headerToSend, fetch);
+    const eventsToOpen = filterEventsToOpen(events, new Date());
 
-  async function updateEvents(eventsToUpdate) {
-    try {
-      const res = await fetch(`${url}/api/events/batchUpdate`, {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-customrequired-header': headerToSend,
-        },
-        body: JSON.stringify(eventsToUpdate),
-      });
-      if (!res.ok) throw new Error('Failed to update event');
-      return await res.json();
-    } catch (error) {
-      console.error('Error updating event:', error);
-      return null;
-    }
-  }
-
-  async function sortAndFilterEvents() {
-    const events = await fetchEvents();
-
-    const now = Date.now();
-    const thirtyMinutesFromNow = now + 1800000;
-
-    if (events && events.length > 0) {
-      const sortedEvents = events.filter((event) => {
-        if (!event.date) {
-          return false;
-        }
-        const startMs = new Date(event.date).getTime();
-        if (Number.isNaN(startMs)) return false;
-        return startMs >= now && startMs <= thirtyMinutesFromNow && event.checkInReady === false;
-      });
-      return sortedEvents;
-    }
-  }
-
-  async function openCheckins(events) {
-    if (events && events.length > 0) {
-      console.log('Opening check-ins');
-      const batchEventsToUpdate = events.map((e) => ({
+    if (eventsToOpen.length > 0) {
+      const batchEventsToUpdate = eventsToOpen.map((e) => ({
         _id: e._id,
         checkInReady: true,
       }));
-      const updatedEvents = await updateEvents(batchEventsToUpdate);
+      const updatedEvents = await updateEvents(url, headerToSend, fetch, batchEventsToUpdate);
       if (updatedEvents) console.log('Updated events:', updatedEvents);
       console.log('Check-ins opened');
     } else {
@@ -75,19 +80,7 @@ export default (cron, fetch) => {
     }
   }
 
-  async function runTask() {
-    const eventsToOpen = await sortAndFilterEvents().catch((err) => {
-      console.log(err);
-    });
-
-    await openCheckins(eventsToOpen).catch((err) => {
-      console.log(err);
-    });
-  }
-
-  const scheduledTask = cron.schedule('*/30 * * * *', () => {
+  return cron.schedule('*/30 * * * *', () => {
     runTask();
   });
-
-  return scheduledTask;
 };

--- a/backend/workers/openCheckins.js
+++ b/backend/workers/openCheckins.js
@@ -1,79 +1,78 @@
+import adjustToLosAngelesTime from './lib/adjustToLosAngelesTime.js';
+
+const THIRTY_MINUTES_MS = 1800000;
+
+// --- Testable pure function (exported) ---
+
+export function filterEventsToOpen(events, now) {
+  if (!events || events.length === 0) return [];
+
+  const laNow = adjustToLosAngelesTime(now);
+  const laNowMs = laNow.getTime();
+  const thirtyMinutesFromNow = laNowMs + THIRTY_MINUTES_MS;
+
+  return events.filter((event) => {
+    if (!event.date) return false;
+    const eventDate = new Date(event.date);
+    if (Number.isNaN(eventDate.getTime())) return false;
+    const startMs = adjustToLosAngelesTime(eventDate).getTime();
+    return startMs >= laNowMs && startMs <= thirtyMinutesFromNow && event.checkInReady === false;
+  });
+}
+
+// --- Side-effectful functions ---
+
+async function fetchEvents(url, headerToSend, fetch) {
+  try {
+    const res = await fetch(`${url}/api/events`, {
+      headers: { 'x-customrequired-header': headerToSend },
+    });
+    return await res.json();
+  } catch (error) {
+    console.log(error);
+    return [];
+  }
+}
+
+async function updateEvents(url, headerToSend, fetch, eventsToUpdate) {
+  try {
+    const res = await fetch(`${url}/api/events/batchUpdate`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-customrequired-header': headerToSend,
+      },
+      body: JSON.stringify(eventsToUpdate),
+    });
+    if (!res.ok) throw new Error('Failed to update event');
+    return await res.json();
+  } catch (error) {
+    console.error('Error updating event:', error);
+    return null;
+  }
+}
+
+// --- Entrypoint ---
+
 export default (cron, fetch) => {
   const url =
     process.env.NODE_ENV === 'prod'
       ? 'https://www.vrms.io'
-      : `http://localhost:${process.env.BACKEND_PORT}`;
-  const headerToSend = process.env.CUSTOM_REQUEST_HEADER;
+      : `http://localhost:${process.env.BACKEND_PORT || 4000}`;
+  const headerToSend = process.env.CUSTOM_REQUEST_HEADER ?? '';
 
-  async function fetchEvents() {
-    try {
-      const res = await fetch(`${url}/api/events`, {
-        headers: {
-          'x-customrequired-header': headerToSend,
-        },
-      });
-      const resJson = await res.json();
+  async function runTask() {
+    console.log('Opening check-ins');
 
-      return resJson;
-    } catch (error) {
-      console.log(error);
-    }
-  }
+    const events = await fetchEvents(url, headerToSend, fetch);
+    const eventsToOpen = filterEventsToOpen(events, new Date());
 
-  async function updateEvents(eventsToUpdate) {
-    try {
-      const res = await fetch(`${url}/api/events/batchUpdate`, {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-customrequired-header': headerToSend,
-        },
-        body: JSON.stringify(eventsToUpdate),
-      });
-      if (!res.ok) throw new Error('Failed to update event');
-      return await res.json();
-    } catch (error) {
-      console.error('Error updating event:', error);
-      return null;
-    }
-  }
-
-  async function sortAndFilterEvents(currentTime) {
-    const events = await fetchEvents();
-
-    // Get current time in LA and set to date variable
-    const now = new Date();
-    const laNow = new Date(now.toLocaleString('en-US', { timeZone: 'America/Los_Angeles' }));
-    const laNowMs = laNow.getTime();
-    // Calculate thirty minutes from now
-    const thirtyMinutesFromLaNow = laNowMs + 1800000;
-
-    if (events && events.length > 0) {
-      const sortedEvents = events.filter((event) => {
-        if (!event.date) {
-          // handle if event date is null/undefined
-          // false meaning don't include in sortedEvents
-          console.log('Events exist but no date');
-          return false;
-        }
-        const startMs = new Date(event.date).getTime();
-        if (Number.isNaN(startMs)) return false;
-        return (
-          startMs >= laNowMs && startMs <= thirtyMinutesFromLaNow && event.checkInReady === false
-        );
-      });
-      return sortedEvents;
-    }
-  }
-
-  async function openCheckins(events) {
-    if (events && events.length > 0) {
-      console.log('Opening check-ins');
-      const batchEventsToUpdate = events.map((e) => ({
+    if (eventsToOpen.length > 0) {
+      const batchEventsToUpdate = eventsToOpen.map((e) => ({
         _id: e._id,
         checkInReady: true,
       }));
-      const updatedEvents = await updateEvents(batchEventsToUpdate);
+      const updatedEvents = await updateEvents(url, headerToSend, fetch, batchEventsToUpdate);
       if (updatedEvents) console.log('Updated events:', updatedEvents);
       console.log('Check-ins opened');
     } else {
@@ -81,20 +80,7 @@ export default (cron, fetch) => {
     }
   }
 
-  async function runTask() {
-    console.log('Opening check-ins');
-
-    const currentTime = new Date();
-
-    const eventsToOpen = await sortAndFilterEvents(currentTime);
-    await openCheckins(eventsToOpen);
-
-    console.log('Check-ins opened');
-  }
-
-  const scheduledTask = cron.schedule('*/30 * * * *', () => {
+  return cron.schedule('*/30 * * * *', () => {
     runTask();
   });
-
-  return scheduledTask;
 };

--- a/backend/workers/openCheckins.test.js
+++ b/backend/workers/openCheckins.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import MockDate from 'mockdate';
+
+// Unmock — vitest.setup.js globally mocks all workers
+vi.unmock('./openCheckins.js');
+
+import { filterEventsToOpen } from './openCheckins.js';
+
+describe('openCheckins — filterEventsToOpen', () => {
+  afterEach(() => {
+    MockDate.reset();
+  });
+
+  const makeEvent = (date, checkInReady = false) => ({
+    _id: `evt-${date}`,
+    name: 'Test Event',
+    date,
+    checkInReady,
+  });
+
+  // --- Basic behavior ---
+
+  it('returns empty array when no events', () => {
+    expect(filterEventsToOpen([], new Date())).toEqual([]);
+    expect(filterEventsToOpen(null, new Date())).toEqual([]);
+  });
+
+  it('skips events with no date', () => {
+    const events = [{ _id: '1', name: 'No Date', checkInReady: false }];
+    expect(filterEventsToOpen(events, new Date())).toEqual([]);
+  });
+
+  it('skips events with invalid date strings', () => {
+    const events = [makeEvent('not-a-date', false)];
+    expect(filterEventsToOpen(events, new Date())).toEqual([]);
+  });
+
+  it('skips events already open for check-in', () => {
+    MockDate.set('2024-01-15T18:50:00Z');
+    const events = [makeEvent('2024-01-15T19:00:00Z', true)];
+    expect(filterEventsToOpen(events, new Date())).toEqual([]);
+  });
+
+  it('opens event starting within 30 minutes', () => {
+    MockDate.set('2024-01-15T18:50:00Z');
+    const events = [makeEvent('2024-01-15T19:00:00Z', false)];
+    const result = filterEventsToOpen(events, new Date());
+    expect(result).toHaveLength(1);
+  });
+
+  it('does NOT open event more than 30 minutes away', () => {
+    MockDate.set('2024-01-15T18:00:00Z');
+    const events = [makeEvent('2024-01-15T19:00:00Z', false)];
+    expect(filterEventsToOpen(events, new Date())).toEqual([]);
+  });
+
+  it('does NOT open event already in the past', () => {
+    MockDate.set('2024-01-15T20:00:00Z');
+    const events = [makeEvent('2024-01-15T19:00:00Z', false)];
+    expect(filterEventsToOpen(events, new Date())).toEqual([]);
+  });
+
+  // --- DST: timezone-aware comparison ---
+
+  it('spring forward: event within 30 min during PDT', () => {
+    // Event at 03:00 UTC. At 02:50 UTC → 10 min before → open.
+    MockDate.set('2024-03-13T02:50:00Z');
+    const events = [makeEvent('2024-03-13T03:00:00Z', false)];
+    const result = filterEventsToOpen(events, new Date());
+    expect(result).toHaveLength(1);
+  });
+
+  it('spring forward: event NOT within 30 min during PDT', () => {
+    // Event at 03:00 UTC. At 02:00 UTC → 60 min before → skip.
+    MockDate.set('2024-03-13T02:00:00Z');
+    const events = [makeEvent('2024-03-13T03:00:00Z', false)];
+    expect(filterEventsToOpen(events, new Date())).toEqual([]);
+  });
+
+  it('fall back: event within 30 min during PST', () => {
+    // Event at 02:00 UTC. At 01:50 UTC → 10 min before → open.
+    MockDate.set('2024-11-06T01:50:00Z');
+    const events = [makeEvent('2024-11-06T02:00:00Z', false)];
+    const result = filterEventsToOpen(events, new Date());
+    expect(result).toHaveLength(1);
+  });
+
+  it('fall back: event NOT within 30 min during PST', () => {
+    MockDate.set('2024-11-06T01:00:00Z');
+    const events = [makeEvent('2024-11-06T02:00:00Z', false)];
+    expect(filterEventsToOpen(events, new Date())).toEqual([]);
+  });
+
+  // --- Multiple events ---
+
+  it('handles multiple events, returning only eligible ones', () => {
+    MockDate.set('2024-01-15T18:50:00Z');
+    const events = [
+      makeEvent('2024-01-15T19:00:00Z', false), // 10 min away, closed → open
+      makeEvent('2024-01-15T20:00:00Z', false), // 70 min away → skip
+      makeEvent('2024-01-15T19:10:00Z', false), // 20 min away, closed → open
+      makeEvent('2024-01-15T19:00:00Z', true), // 10 min away, already open → skip
+    ];
+    const result = filterEventsToOpen(events, new Date());
+    expect(result).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## What
Refactor checkin workers for testability and timezone safety (#1872).

## Why
The open/close checkin workers had all logic trapped inside closure-based default exports, making them impossible to unit test. Additionally, time comparisons used raw `Date.now()` without accounting for LA timezone, which could cause incorrect behavior during DST transitions.

## Changes
- Extract `adjustToLosAngelesTime` from `createRecurringEvents.js` into shared `lib/adjustToLosAngelesTime.js`
- Export pure filter functions (`filterEventsToOpen`, `filterEventsToClose`) as named exports
- Apply `adjustToLosAngelesTime` to both `now` and event dates for DST-safe comparison
- Add 30 new tests covering basic filtering, DST transitions (spring forward/fall back), edge cases, and multiple events
- Preserve existing `batchUpdate` API behavior

## Testing
All 50 worker tests pass (30 new + 20 existing `createRecurringEvents` tests).

## Related
- Closes #1872
- Builds on approach from #2116 by @Ganeshswaminathan1912
- Follow-up PR for TypeScript conversion: depends on this PR