### PR TITLE
fix(docker): bump Dockerfile.prod from node:18.12.0 to node:24

### DIFF
--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM node:18.12.0 AS api-builder
+FROM node:24 AS api-builder
 RUN mkdir /srv/backend
 WORKDIR /srv/backend
 RUN mkdir -p node_modules
@@ -6,7 +6,7 @@ COPY package.json yarn.lock ./
 RUN yarn install --pure-lockfile
 COPY . .
 
-FROM node:18.12.0-slim AS api-production
+FROM node:24-slim AS api-production
 ARG BUILD_SHA
 EXPOSE 4000
 WORKDIR /srv/backend


### PR DESCRIPTION
## Problem

The production deploy is broken. CI run [#27797327895](https://github.com/hackforla/VRMS/actions/runs/27797327895) fails with:

```
error mongodb-memory-server@11.1.0: The engine "node" is incompatible with this module. Expected version ">=20.19.0". Got "18.12.0"
```

## Root cause

`Dockerfile.prod` was still pinned to `node:18.12.0` while `.nvmrc` and `Dockerfile.api` already use Node 24.

## Fix

Bump both stages in `Dockerfile.prod` to `node:24` / `node:24-slim` to match the rest of the project.